### PR TITLE
Bug fix for removing indices with custom names

### DIFF
--- a/lib/classes/class.Ruckusing_BaseMigration.php
+++ b/lib/classes/class.Ruckusing_BaseMigration.php
@@ -50,8 +50,8 @@ class Ruckusing_BaseMigration {
 		return $this->adapter->add_index($table_name, $column_name, $options);			
 	}
 	
-	public function remove_index($table_name, $column_name) {
-		return $this->adapter->remove_index($table_name, $column_name);					
+	public function remove_index($table_name, $column_name, $options = array()) {
+		return $this->adapter->remove_index($table_name, $column_name, $options);
 	}
 	
 	public function create_table($table_name, $options = array()) {


### PR DESCRIPTION
Indices with custom names couldn't be removed using `remove_index` because `Ruckusing_BaseMigration::remove_index` didn't pass along the `$options` array.
