### PR TITLE
Added an options check when adding a unique index

### DIFF
--- a/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
+++ b/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
@@ -387,7 +387,7 @@ class Ruckusing_MySQLAdapter extends Ruckusing_BaseAdapter implements Ruckusing_
 			throw new Ruckusing_ArgumentException("Missing column name parameter");
 		}
 		//unique index?
-		if(is_array($options) && array_key_exists('unique', $options)) {
+		if(is_array($options) && array_key_exists('unique', $options) && $options['unique'] === true) {
 			$unique = true;
 		} else {
 			$unique = false;


### PR DESCRIPTION
I ran into a problem where I was setting the unique option to false,
but the index was still being created because the unique key existed in
the options array (the value of unique was never checked).
