### PR TITLE
Migrations Directory - Undefined Constant

### DIFF
--- a/lib/classes/class.Ruckusing_FrameworkRunner.php
+++ b/lib/classes/class.Ruckusing_FrameworkRunner.php
@@ -149,7 +149,7 @@ class Ruckusing_FrameworkRunner {
 	  $this->adapter->create_schema_version_table();
 	  //insert all existing records into our new table
 	  $migrator_util = new Ruckusing_MigratorUtil($this->adapter);
-	  $files = $migrator_util->get_migration_files(RUCKUSING_MIGRATION_DIR, 'up');
+	  $files = $migrator_util->get_migration_files($this->migrations_directory(), 'up');
     foreach($files as $file) {
       if( (int)$file['version'] >= PHP_INT_MAX) {
         //its new style like '20081010170207' so its not a candidate

--- a/lib/tasks/class.Ruckusing_DB_Status.php
+++ b/lib/tasks/class.Ruckusing_DB_Status.php
@@ -24,7 +24,7 @@ class Ruckusing_DB_Status extends Ruckusing_Task implements Ruckusing_iTask {
     echo "[db:status]: \n";
     $util = new Ruckusing_MigratorUtil($this->get_adapter());
     $migrations = $util->get_executed_migrations();
-    $files = $util->get_migration_files(RUCKUSING_MIGRATION_DIR, 'up');
+    $files = $util->get_migration_files($this->get_framework()->migrations_directory(), 'up');
     $applied = array();
     $not_applied = array();
     foreach($files as $file) {


### PR DESCRIPTION
There were a couple of references to a previously-removed constant, RUCKUSING_MIGRATION_DIR.  I removed those and replaced them with a call to the migrations_directory() method.
