### PR TITLE
Fix for add_column failure if table name is a reserved word.

### DIFF
--- a/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
+++ b/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
@@ -303,7 +303,7 @@ class Ruckusing_MySQLAdapter extends Ruckusing_BaseAdapter implements Ruckusing_
 		if(!array_key_exists('scale', $options)) {
 			$options['scale'] = null;
 		}
-		$sql = sprintf("ALTER TABLE %s ADD `%s` %s", $table_name, $column_name, $this->type_to_sql($type,$options));
+		$sql = sprintf("ALTER TABLE %s ADD `%s` %s", $this->identifier($table_name), $column_name, $this->type_to_sql($type,$options));
 		$sql .= $this->add_column_options($type, $options);
 		return $this->execute_ddl($sql);
 	}//add_column


### PR DESCRIPTION
Passed unit tests.
