### PR TITLE
Support for setting the collation for a column.

### DIFF
--- a/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
+++ b/lib/classes/adapters/class.Ruckusing_MySQLAdapter.php
@@ -367,7 +367,7 @@ class Ruckusing_MySQLAdapter extends Ruckusing_BaseAdapter implements Ruckusing_
 			throw new Ruckusing_ArgumentException("Missing original column name parameter");
 		}
 		try {
-			$sql = sprintf("SHOW COLUMNS FROM %s LIKE '%s'", $this->identifier($table), $column);
+			$sql = sprintf("SHOW FULL COLUMNS FROM %s LIKE '%s'", $this->identifier($table), $column);
 			$result = $this->select_one($sql);
 			if(is_array($result)) {
 			  //lowercase key names
@@ -597,6 +597,9 @@ class Ruckusing_MySQLAdapter extends Ruckusing_BaseAdapter implements Ruckusing_
 
 		if(array_key_exists('null', $options) && $options['null'] === false) {
 			$sql .= " NOT NULL";
+		}
+		if (array_key_exists('collate', $options)) {
+			$sql .= sprintf(" COLLATE %s", $this->identifier($options['collate']));
 		}
 		if(array_key_exists('comment', $options)) {
             $sql .= sprintf(" COMMENT '%s'", $this->quote_string($options['comment']));

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -226,6 +226,12 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase {
     $col = $this->adapter->column_info("users", "weight");
     $this->assertEquals("weight", $col['field']);
     $this->assertEquals('bigint(20)', $col['type'] );
+
+    // Test that the collate option works
+    $this->adapter->add_column('users', 'shortcode', 'string', array('collate' => 'utf8_bin'));
+    $col = $this->adapter->column_info('users', 'shortcode');
+    $this->assertEquals('utf8_bin', $col['collation']);
+
     $this->remove_table('users');
   }
 
@@ -262,6 +268,13 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase {
     $col = $this->adapter->column_info("users", "name");
     $this->assertEquals('varchar(128)', $col['type'] );
     $this->assertEquals('abc', $col['default'] );
+
+    // Test collate option
+    $this->adapter->change_column("users", "name", "string", array('default' => 'abc', 'limit' => 128, 
+      'collate' => 'ascii_bin'));
+    $col = $this->adapter->column_info('users', 'name');
+    $this->assertEquals('ascii_bin', $col['collation']);
+
     $this->remove_table('users');
   }
 


### PR DESCRIPTION
1. Added additional tests. All tests pass.
2. I don't think it will be a problem but please note that I changed [Ruckusing_MySQLAdapter->column_info()](https://github.com/shiki/ruckusing-migrations/commit/29e6f140abad55d84f8a2c0729afe65a84d6bb37#L0L370) to use `SHOW FULL COLUMNS` so the collation info will be returned as well. I'm only using that for the tests though.
