### PR TITLE
fix config db ENV not being set from the arguments if supplied

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -25,7 +25,7 @@ require RUCKUSING_BASE . '/lib/classes/util/class.Ruckusing_MigratorUtil.php';
 require RUCKUSING_BASE . '/lib/classes/class.Ruckusing_FrameworkRunner.php';
 
 $args = parse_args($argv);
-$framework = new Ruckusing_FrameworkRunner($config, null);
+$framework = new Ruckusing_FrameworkRunner($config, $argv);
 //input sanity check
 if(!is_array($args) || (is_array($args) && !array_key_exists('name', $args)) ) {
   print_help(true);


### PR DESCRIPTION
```
php generate.php create_users_table ENV=dev_Db_Tieba                 


(class.Ruckusing_FrameworkRunner.php:98) 
Error: 'development' DB is not configured
```

ENV is not being set if it is supplied on the command line. This pr is to fix that.

Thanks
