### PR TITLE
arrange db schema files to reflect different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 logs/*.log
 tests/logs/*.log
-tests/dummy/db/schema.txt
+tests/dummy/db/ruckusing_migrations_test/schema.txt
 .DS*
 .idea
 tmp/

--- a/lib/classes/class.Ruckusing_FrameworkRunner.php
+++ b/lib/classes/class.Ruckusing_FrameworkRunner.php
@@ -121,6 +121,16 @@ class Ruckusing_FrameworkRunner
     }
 
     /**
+     * Get the current db schema dir
+     *
+     * @return string
+     */
+    public function db_directory()
+    {
+        return RUCKUSING_DB_DIR . DIRECTORY_SEPARATOR . $this->config['db'][$this->ENV]['database'];
+    }
+
+    /**
      * Initialize the db
      */
     public function initialize_db()

--- a/lib/tasks/class.Ruckusing_DB_Schema.php
+++ b/lib/tasks/class.Ruckusing_DB_Schema.php
@@ -35,22 +35,10 @@ class Ruckusing_DB_Schema extends Ruckusing_Task implements Ruckusing_iTask
             echo "Started: " . date('Y-m-d g:ia T') . "\n\n";
             echo "[db:schema]: \n";
 
-            if (!is_dir(RUCKUSING_DB_DIR)) {
-                echo "\n\tDB Schema directory (".RUCKUSING_DB_DIR." doesn't exist, attempting to create.\n";
-                if (mkdir(RUCKUSING_DB_DIR) === FALSE) {
-                    echo "\n\tUnable to create migrations directory at ".RUCKUSING_DB_DIR.", check permissions?\n";
-                } else {
-                    echo "\n\tCreated OK\n\n";
-                }
-            }
-
-            //check to make sure our destination directory is writable
-            if (!is_writable(RUCKUSING_DB_DIR)) {
-                throw new Exception("ERROR: migration directory '" . RUCKUSING_DB_DIR . "' is not writable by the current user. Check permissions and try again.\n");
-            }
+            $db_directory = $this->db_dir();
 
             //write to disk
-            $schema_file = RUCKUSING_DB_DIR . '/schema.txt';
+            $schema_file = $db_directory . '/schema.txt';
             $schema = $this->get_adapter()->schema($schema_file);
             echo "\tSchema written to: $schema_file\n\n";
             echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
@@ -58,5 +46,32 @@ class Ruckusing_DB_Schema extends Ruckusing_Task implements Ruckusing_iTask
             throw $ex; //re-throw
         }
     }//execute
+
+
+    /**
+     * Get the db dir, check and create the db dir if it doesn't exists
+     *
+     * @return string
+     */
+    private function db_dir()
+    {
+        // create the db directory if it doesnt exist
+        $db_directory = $this->get_framework()->db_directory();
+        if (!is_dir($db_directory)) {
+            printf("\n\tDB Schema directory (%s doesn't exist, attempting to create.\n", $db_directory);
+            if (mkdir($db_directory, 0755, true) === FALSE) {
+                printf("\n\tUnable to create migrations directory at %s, check permissions?\n", $db_directory);
+            } else {
+                printf("\n\tCreated OK\n\n");
+            }
+        }
+
+        //check to make sure our destination directory is writable
+        if (!is_writable($db_directory)) {
+            throw new Exception("ERROR: DB Schema directory '" . $db_directory . "' is not writable by the current user. Check permissions and try again.\n");
+        }
+
+        return $db_directory;
+    }
 
 }//class

--- a/tests/unit/TaskManagerTest.php
+++ b/tests/unit/TaskManagerTest.php
@@ -38,6 +38,12 @@ class TaskManagerTest extends PHPUnit_Framework_TestCase
         $this->adapter = new Ruckusing_MySQLAdapter($test_db, $logger);
         $this->adapter->logger->log("Test run started: " . date('Y-m-d g:ia T'));
 
+        $this->framework = new Ruckusing_FrameworkRunner($ruckusing_config, array('ENV=mysql_test'));
+        $this->db_dir = $this->framework->db_directory();
+        if (!is_dir($this->db_dir)) {
+            mkdir($this->db_dir, 0755, true);
+        }
+
     } //setUp()
 
     /**
@@ -46,7 +52,8 @@ class TaskManagerTest extends PHPUnit_Framework_TestCase
     public function test_db_schema_creation()
     {
         $schema = new Ruckusing_DB_Schema($this->adapter);
+        $schema->set_framework($this->framework);
         $schema->execute(array());
-        $this->assertEquals(true, file_exists(RUCKUSING_DB_DIR . '/schema.txt'));
+        $this->assertEquals(true, file_exists($this->db_dir . '/schema.txt'));
     }
 }


### PR DESCRIPTION
Hi,

Sometimes an app has many databases. Thus in ruckusing-migrations terms, you will will need different 'ENV' in your configuration to track changes to those databases. But when generating db schemas for different ENV, they will overwrite each other. 
This pr add the database name to the end of the specified db directory to structure db schema files according to their corresponding database.

Thanks
