### PR TITLE
add help to tasks to show some descriptions about each task

### DIFF
--- a/lib/classes/task/class.Ruckusing_TaskManager.php
+++ b/lib/classes/task/class.Ruckusing_TaskManager.php
@@ -179,4 +179,17 @@ class Ruckusing_TaskManager
         return "";
     }
 
+    /**
+     * Get display help of task
+     *
+     * @param string $task_name The task name
+     *
+     * @return string
+     */
+    public function help($task_name)
+    {
+        $task = $this->get_task($task_name);
+        return $task->help();
+    }
+
 }

--- a/lib/classes/task/class.Ruckusing_iTask.php
+++ b/lib/classes/task/class.Ruckusing_iTask.php
@@ -10,5 +10,19 @@
  */
 interface Ruckusing_iTask
 {
+    /**
+     * execute the task
+     *
+     * @param array $args Argument to the task
+     *
+     * @return string
+     */
     public function execute($args);
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help();
 }

--- a/lib/tasks/class.Ruckusing_DB_Generate.php
+++ b/lib/tasks/class.Ruckusing_DB_Generate.php
@@ -33,10 +33,10 @@ class Ruckusing_DB_Generate extends Ruckusing_Task implements Ruckusing_iTask
     {
         // Add support for old migration style
         if (!is_array($args) || !array_key_exists('name', $args)) {
-            $cargs = self::parse_args($_SERVER['argv']);
+            $cargs = $this->parse_args($_SERVER['argv']);
             //input sanity check
             if (!is_array($cargs) || !array_key_exists('name', $cargs)) {
-                self::print_help(true);
+                $this->print_help(true);
             }
             $migration_name = $cargs['name'];
         }
@@ -87,7 +87,7 @@ class Ruckusing_DB_Generate extends Ruckusing_Task implements Ruckusing_iTask
      * @param  array $argv The current supplied command line arguments.
      * @return array ('name' => 'name')
      */
-    public static function parse_args($argv)
+    public function parse_args($argv)
     {
         foreach ($argv as $i => $arg) {
             if (strpos($arg, '=') !== FALSE) {
@@ -96,7 +96,7 @@ class Ruckusing_DB_Generate extends Ruckusing_Task implements Ruckusing_iTask
         }
         $num_args = count($argv);
         if ($num_args < 3) {
-            self::print_help(true);
+            $this->print_help(true);
         }
         $migration_name = $argv[2];
 
@@ -109,11 +109,9 @@ class Ruckusing_DB_Generate extends Ruckusing_Task implements Ruckusing_iTask
      *
      * @param boolean $exit should die after or not
      */
-    public static function print_help($exit = false)
+    public function print_help($exit = false)
     {
-        echo "\nusage: php main.php db:generate <migration name>\n\n";
-        echo "\tWhere <migration name> is a descriptive name of the migration, joined with underscores.\n";
-        echo "\tExamples: add_index_to_users | create_users_table | remove_pending_users\n\n";
+        echo $this->help();
         if ($exit) {
             die;
         }
@@ -154,6 +152,30 @@ class $klass extends Ruckusing_BaseMigration
 TPL;
 
         return $template;
+    }
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:generate <migration name>
+
+\tGenerator for migrations.
+
+\t<migration name> is a descriptive name of the migration,
+\tjoined with underscores. e.g.: add_index_to_users | create_users_table
+
+\tExample :
+
+\t\tphp {$_SERVER['argv'][0]} db:generate add_index_to_users
+
+USAGE;
+        return $output;
     }
 
 }

--- a/lib/tasks/class.Ruckusing_DB_Migrate.php
+++ b/lib/tasks/class.Ruckusing_DB_Migrate.php
@@ -305,4 +305,42 @@ class Ruckusing_DB_Migrate extends Ruckusing_Task implements Ruckusing_iTask
         }
     }
 
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:migrate [VERSION]
+
+\tThe primary purpose of the framework is to run migrations, and the
+\texecution of migrations is all handled by just a regular ol' task.
+
+\tVERSION can be specified to go up (or down) to a specific
+\tversion, based on the current version. If not specified,
+\tall migrations greater than the current database version
+\twill be executed.
+
+\tExample A: The database is fresh and empty, assuming there
+\tare 5 actual migrations, but only the first two should be run.
+
+\t\tphp {$_SERVER['argv'][0]} db:migrate VERSION=20101006114707
+
+\tExample B: The current version of the DB is 20101006114707
+\tand we want to go down to 20100921114643
+
+\t\tphp {$_SERVER['argv'][0]} db:migrate VERSION=20100921114643
+
+\tExample C: You can also use relative number of revisions
+\t(positive migrate up, negative migrate down).
+
+\t\tphp {$_SERVER['argv'][0]} db:migrate VERSION=-2
+
+USAGE;
+        return $output;
+    }
+
 }//class

--- a/lib/tasks/class.Ruckusing_DB_Schema.php
+++ b/lib/tasks/class.Ruckusing_DB_Schema.php
@@ -73,4 +73,28 @@ class Ruckusing_DB_Schema extends Ruckusing_Task implements Ruckusing_iTask
         return $db_directory;
     }
 
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:schema
+
+\tIt can be beneficial to get a dump of the DB in raw SQL format which represents
+\tthe current version.
+
+\tNote: This dump only contains the actual schema (e.g. the DML needed to
+\treconstruct the DB), but not any actual data.
+
+\tIn MySQL terms, this task would not be the same as running the mysqldump command
+\t(which by defaults does include any data in the tables).
+
+USAGE;
+        return $output;
+    }
+
 }//class

--- a/lib/tasks/class.Ruckusing_DB_Setup.php
+++ b/lib/tasks/class.Ruckusing_DB_Setup.php
@@ -44,4 +44,24 @@ class Ruckusing_DB_Setup extends Ruckusing_Task implements Ruckusing_iTask
         }
         echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
     }
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:setup
+
+\tA basic task to initialize your DB for migrations is available. One should
+\talways run this task when first starting out.
+
+\tThis task does not take arguments.
+
+USAGE;
+        return $output;
+    }
 }

--- a/lib/tasks/class.Ruckusing_DB_Status.php
+++ b/lib/tasks/class.Ruckusing_DB_Status.php
@@ -58,4 +58,24 @@ class Ruckusing_DB_Status extends Ruckusing_Task implements Ruckusing_iTask
 
         echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
     }
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:status
+
+\tWith this task you'll get an overview of the already executed migrations and
+\twhich will be executed when running db:migrate.
+
+\tThis task does not take arguments.
+
+USAGE;
+        return $output;
+    }
 }

--- a/lib/tasks/class.Ruckusing_DB_Version.php
+++ b/lib/tasks/class.Ruckusing_DB_Version.php
@@ -57,4 +57,24 @@ class Ruckusing_DB_Version extends Ruckusing_Task implements Ruckusing_iTask
         }
         echo "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
     }
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: db:version
+
+\tIt is always possible to ask the framework (really the DB) what version it is
+\tcurrently at.
+
+\tThis task does not take arguments.
+
+USAGE;
+        return $output;
+    }
 }

--- a/lib/tasks/class.Ruckusing_Hello_World.php
+++ b/lib/tasks/class.Ruckusing_Hello_World.php
@@ -28,4 +28,23 @@ class Ruckusing_Hello_World extends Ruckusing_Task implements Ruckusing_iTask
     {
         echo "\nHello, World\n";
     }
+
+    /**
+     * Return the usage of the task
+     *
+     * @return string
+     */
+    public function help()
+    {
+        $output =<<<USAGE
+
+\tTask: hello:world
+
+\tHello World.
+
+\tThis task does not take arguments.
+
+USAGE;
+        return $output;
+    }
 }


### PR DESCRIPTION
``` shell
php main.php help                                                                                                                                                 

    Usage: php main.php <task> [help] [task parameters] [ENV=environment]

    help: Display this message

    ENV: The ENV command line parameter can be used to specify a different
    database to run against, as specific in the configuration file
    (config/database.inc.php).
    By default, ENV is "development"

    task: In a nutshell, task names are pseudo-namespaced. The tasks that come
    with the framework are namespaced to "db" (e.g. the tasks are "db:migrate",
    "db:setup", etc).
    All tasks available actually :

    - db:setup : A basic task to initialize your DB for migrations is
    available. One should always run this task when first starting out.

    - db:generate : A generic task which acts as a Generator for migrations.

    - db:migrate : The primary purpose of the framework is to run migrations,
    and the execution of migrations is all handled by just a regular ol' task.

    - db:version : It is always possible to ask the framework (really the DB)
    what version it is currently at.

    - db:status : With this taks you'll get an overview of the already
    executed migrations and which will be executed when running db:migrate

    - db:schema : It can be beneficial to get a dump of the DB in raw SQL
    format which represents the current version.

```

``` shell
php main.php db:generate help                                                                                                                                 

    Task: db:generate <migration name>

    Generator for migrations.

    <migration name> is a descriptive name of the migration,
    joined with underscores. e.g.: add_index_to_users | create_users_table

    Example :

        php main.php db:generate add_index_to_users

```

``` shell
php main.php db:migrate help                                                                                                                                  

    Task: db:migrate [VERSION]

    The primary purpose of the framework is to run migrations, and the
    execution of migrations is all handled by just a regular ol' task.

    VERSION can be specified to go up (or down) to a specific
    version, based on the current version. If not specified,
    all migrations greater than the current database version
    will be executed.

    Example A: The database is fresh and empty, assuming there
    are 5 actual migrations, but only the first two should be run.

        php main.php db:migrate VERSION=20101006114707

    Example B: The current version of the DB is 20101006114707
    and we want to go down to 20100921114643

        php main.php db:migrate VERSION=20100921114643

    Example C: You can also use relative number of revisions
    (positive migrate up, negative migrate down).

        php main.php db:migrate VERSION=-2

```
