### PR TITLE
add __call magic method to catch some method missing

### DIFF
--- a/lib/Ruckusing/Adapter/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/TableDefinition.php
@@ -52,6 +52,22 @@ class Ruckusing_Adapter_TableDefinition
     }
 
     /**
+     * __call
+     *
+     * @param string $name The method name
+     * @param array  $args The parameters of method called
+     *
+     * @throws Ruckusing_Exception
+     */
+    public function __call($name, $args)
+    {
+        throw new Ruckusing_Exception(
+                'Method unknown (' . $name . ')',
+                Ruckusing_Exception::INVALID_MIGRATION_METHOD
+        );
+    }
+
+    /**
      * Determine whether or not the given column already exists in our
      * table definition.
      *

--- a/lib/Ruckusing/Exception.php
+++ b/lib/Ruckusing/Exception.php
@@ -34,6 +34,7 @@ class Ruckusing_Exception extends Exception
     const INVALID_MIGRATION_DIR = 110;
     const INVALID_FRAMEWORK = 111;
     const QUERY_ERROR = 112;
+    const INVALID_MIGRATION_METHOD = 113;
 
     /**
      * Redefine the exception so message isn't optional

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -29,6 +29,22 @@ class Ruckusing_Migration_Base
     private $_adapter;
 
     /**
+     * __call
+     *
+     * @param string $name The method name
+     * @param array  $args The parameters of method called
+     *
+     * @throws Ruckusing_Exception
+     */
+    public function __call($name, $args)
+    {
+        throw new Ruckusing_Exception(
+                'Method unknown (' . $name . ')',
+                Ruckusing_Exception::INVALID_MIGRATION_METHOD
+        );
+    }
+
+    /**
      * Set an adapter
      *
      * @param Ruckusing_Adapter_Base $adapter the adapter to set


### PR DESCRIPTION
in `TableDefinition` and `Migration`, if a method doesn't exist throw a `Ruckusing_Exception`
Thanks
