### PR TITLE
supply the current adapter on Migration_Base construct

### DIFF
--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -29,6 +29,18 @@ class Ruckusing_Migration_Base
     private $_adapter;
 
     /**
+     * __construct
+     *
+     * @param Ruckusing_Adapter_Base $adapter the current adapter
+     *
+     * @return void
+     */
+    public function __construct($adapter)
+    {
+        $this->set_adapter($adapter);
+    }
+
+    /**
      * __call
      *
      * @param string $name The method name
@@ -58,6 +70,7 @@ class Ruckusing_Migration_Base
             );
         }
         $this->_adapter = $adapter;
+        return $this;
     }
 
     /**

--- a/tests/unit/BaseMigrationTest.php
+++ b/tests/unit/BaseMigrationTest.php
@@ -65,8 +65,7 @@ class BaseMigrationTest extends PHPUnit_Framework_TestCase
     {
         //create it
         $this->adapter->execute_ddl("CREATE TABLE `users` ( name varchar(20), age int(3) );");
-        $base = new Ruckusing_Migration_Base();
-        $base->set_adapter($this->adapter);
+        $base = new Ruckusing_Migration_Base($this->adapter);
         $base->add_index("users", "name", array('name' => 'my_special_index'));
 
         //ensure it exists

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -147,8 +147,7 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
      */
     public function test_index_name_too_long_throws_exception()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         try {
             srand();
             $table_name = "users_" . rand(0, 1000000);

--- a/tests/unit/MySQLTableDefinitionTest.php
+++ b/tests/unit/MySQLTableDefinitionTest.php
@@ -115,8 +115,7 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_limit()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -133,8 +132,7 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_not_null()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -152,8 +150,7 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_default_value()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -171,8 +168,7 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_multiple_primary_keys()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name, array('id' => false));
@@ -196,8 +192,7 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_custom_primary_key_with_auto_increment()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name, array('id' => false));

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -175,8 +175,7 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
      */
     public function test_index_name_too_long_throws_exception()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         try {
             srand();
             $table_name = "users_" . rand(0, 1000000);

--- a/tests/unit/PostgresTableDefinitionTest.php
+++ b/tests/unit/PostgresTableDefinitionTest.php
@@ -115,8 +115,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_limit()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -133,8 +132,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_not_null()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -152,8 +150,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_column_definition_with_default_value()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name);
@@ -171,8 +168,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_multiple_primary_keys()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name, array('id' => false));
@@ -203,8 +199,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     public function test_custom_primary_key_with_auto_increment()
     {
-        $bm = new Ruckusing_Migration_Base();
-        $bm->set_adapter($this->adapter);
+        $bm = new Ruckusing_Migration_Base($this->adapter);
         $ts = time();
         $table_name = "users_${ts}";
         $table = $bm->create_table($table_name, array('id' => false));


### PR DESCRIPTION
a `set_adapter` is always called after `Ruckusing_Migration_Base` is instantiated. This pr makes it to require an adapter during construct to avoid calling another function to set it.
Thanks
