### PR TITLE
Escape MySQL enum values

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -967,7 +967,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                         );
             }
             else {
-                $column_type_sql .= sprintf("('%s')", implode("','", $values));
+                $column_type_sql .= sprintf("('%s')", implode("','", array_map(array($this, 'quote_string'), $values)));
             }
         }  {
             //not a decimal column

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -212,8 +212,8 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
         $expected = "`age` int(11) AFTER `height`";
         $this->assertEquals($expected, $this->adapter->column_definition("age", "integer", array("after" => "height")));
 
-		$expected = "`adapter` enum('mysql','pgsql')";
-        $this->assertEquals($expected, $this->adapter->column_definition("adapter", "enum", array('values' => array('mysql', 'pgsql'))));
+		$expected = "`adapter` enum('mysql','pgsql','ha\'xor')";
+        $this->assertEquals($expected, $this->adapter->column_definition("adapter", "enum", array('values' => array('mysql', 'pgsql', "ha'xor"))));
     }//test_column_definition
 
     /**


### PR DESCRIPTION
MySQL enum values may contain ' character so they must be escaped.
