### PR TITLE
Added support for character set on columns using MySQL adapter 

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -1021,6 +1021,9 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
         if (array_key_exists('null', $options) && $options['null'] === false) {
             $sql .= " NOT NULL";
         }
+        if (array_key_exists('character', $options)) {
+        	$sql .= sprintf(" CHARACTER SET %s", $this->identifier($options['character']));
+        }
         if (array_key_exists('collate', $options)) {
             $sql .= sprintf(" COLLATE %s", $this->identifier($options['collate']));
         }

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -309,6 +309,12 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
         $col = $this->adapter->column_info('users', 'shortcode');
         $this->assertEquals('utf8_bin', $col['collation']);
 
+        // Test that the character option works, default collation of latin1 is latin1_swedish_ci
+        // http://dev.mysql.com/doc/refman/5.0/en/charset-mysql.html
+        $this->adapter->add_column('users', 'highschool', 'string', array('character' => 'latin1'));
+        $col = $this->adapter->column_info('users', 'highschool');
+        $this->assertEquals('latin1_swedish_ci', $col['collation']);
+
         $this->remove_table('users');
     }
 


### PR DESCRIPTION
Hello, 

I couldn't set the character set on columns using MySQL adapter, so have added to the options array...

To set character set on a column add 'character' key value pair to the
$options array passed to add_column or change column.

Eg. $this->add_column('table', 'column', 'string',
array('character'=>'latin1'));

MySQL 5.0 documentation for setting column character set can be found
at http://dev.mysql.com/doc/refman/5.0/en/charset-column.html

MySQL 5.0 documentation of character sets and their default collations
can be found at
http://dev.mysql.com/doc/refman/5.0/en/charset-mysql.html

Thanks,
SB
