### PR TITLE
Added support for mediumint in MySQL adapter

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -108,6 +108,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'mediumtext'    => array('name' => 'mediumtext'),
                 'integer'       => array('name' => "int", 'limit' => 11),
                 'smallinteger'  => array('name' => "smallint"),
+                'mediuminteger'	=> array('name' => "mediumint"),
                 'biginteger'    => array('name' => "bigint"),
                 'float'         => array('name' => "float"),
                 'decimal'       => array('name' => "decimal", 'scale' => 10, 'precision' => 0),

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -108,6 +108,7 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'mediumtext'    => array('name' => 'text'),
                 'integer'       => array('name' => 'integer'),
                 'smallinteger'  => array('name' => 'smallint'),
+                'mediuminteger' => array('name' => 'integer'),
                 'biginteger'    => array('name' => 'bigint'),
                 'float'         => array('name' => 'float'),
                 'decimal'       => array('name' => 'decimal', 'scale' => 10, 'precision' => 0),

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -209,6 +209,9 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
         $expected = "`weight` bigint(20)";
         $this->assertEquals($expected, $this->adapter->column_definition("weight", "biginteger", array('limit' => 20)));
 
+        $expected = "`weight` mediumint(4)";
+        $this->assertEquals($expected, $this->adapter->column_definition("weight", "mediuminteger", array('limit' => 4)));
+
         $expected = "`age` int(11) AFTER `height`";
         $this->assertEquals($expected, $this->adapter->column_definition("age", "integer", array("after" => "height")));
 

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -229,6 +229,9 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
         $expected = '"age" integer';
         $this->assertEquals($expected, $this->adapter->column_definition("age", "integer"));
 
+        $expected = '"age" integer';
+        $this->assertEquals($expected, $this->adapter->column_definition("age", "mediuminteger"));
+
         $expected = '"active" boolean';
         $this->assertEquals($expected, $this->adapter->column_definition("active", "boolean"));
 


### PR DESCRIPTION
Hello, 

I needed to use mediumint, so I've added the column type to the MySQL adapter.

To use mediumint column type, use 'mediuminteger' as type value when
creating or updating a column.

Eg. $this->add_column('table', 'column', 'mediuminteger');

Postgresql has no equivalent for mediumint, so falls back to integer
type when 'mediuminteger' is used.

MySQL 5.0 documentation for the mediumint column type can be found at
http://dev.mysql.com/doc/refman/5.0/en/integer-types.html

Thanks, 
SB
