### PR TITLE
[BUG] Character set and collate must occur in data type definition

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -994,6 +994,13 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             $sql .= ' UNSIGNED';
         }
 
+        if (array_key_exists('character', $options)) {
+        	$sql .= sprintf(" CHARACTER SET %s", $this->identifier($options['character']));
+        }
+        if (array_key_exists('collate', $options)) {
+            $sql .= sprintf(" COLLATE %s", $this->identifier($options['collate']));
+        }
+
         if (array_key_exists('auto_increment', $options) && $options['auto_increment'] === true) {
             $sql .= ' auto_increment';
         }
@@ -1021,12 +1028,6 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
 
         if (array_key_exists('null', $options) && $options['null'] === false) {
             $sql .= " NOT NULL";
-        }
-        if (array_key_exists('character', $options)) {
-        	$sql .= sprintf(" CHARACTER SET %s", $this->identifier($options['character']));
-        }
-        if (array_key_exists('collate', $options)) {
-            $sql .= sprintf(" COLLATE %s", $this->identifier($options['collate']));
         }
         if (array_key_exists('comment', $options)) {
             $sql .= sprintf(" COMMENT '%s'", $this->quote_string($options['comment']));


### PR DESCRIPTION
Resolves issue where an SQL error occurs when defining a character set,
collation, and default value while adding a column to a table. As
character set and collation must occur in the data type definition,
prior to any other item in the column definition, such as default,
auto_increment or comment.

MySQL 5.0 documentation for the syntax of create table can be found at
http://dev.mysql.com/doc/refman/5.0/en/create-table.html

Thanks
SB
