### PR TITLE
[FEATURE] Added configuration value to specify migration directory name

### DIFF
--- a/lib/Ruckusing/FrameworkRunner.php
+++ b/lib/Ruckusing/FrameworkRunner.php
@@ -190,7 +190,14 @@ class Ruckusing_FrameworkRunner
      */
     public function migrations_directory()
     {
-        return $this->_config['migrations_dir'] . DIRECTORY_SEPARATOR . $this->_config['db'][$this->_env]['database'];
+    	$path = $this->_config['migrations_dir'] . DIRECTORY_SEPARATOR;
+
+        if (array_key_exists('directory', $this->_config['db'][$this->_env])) {
+            return $path . $this->_config['db'][$this->_env]['directory'];
+        }
+        else {
+            return $path . $this->_config['db'][$this->_env]['database'];
+        }
     }
 
     /**


### PR DESCRIPTION
Hello, 

I've added optional database environment configuration value to set the name
of the directory that contains migrations to be run on that
environment, where the name of the directory is not equal to the name
of the database.

Where the directory key is not set, database value will be used instead.

Eg. If development database migrations were stored in a directory
within migrations_dir called 'trunk', I would add the following key
value pair to the development array in config.

'directory' => 'trunk'

Thanks, 
SB
