### PR TITLE
[BUG] Default values of scale and precision are reversed.

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -111,7 +111,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'mediuminteger'	=> array('name' => "mediumint"),
                 'biginteger'    => array('name' => "bigint"),
                 'float'         => array('name' => "float"),
-                'decimal'       => array('name' => "decimal", 'scale' => 10, 'precision' => 0),
+                'decimal'       => array('name' => "decimal", 'scale' => 0, 'precision' => 10),
                 'datetime'      => array('name' => "datetime"),
                 'timestamp'     => array('name' => "timestamp"),
                 'time'          => array('name' => "time"),

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -111,7 +111,7 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'mediuminteger' => array('name' => 'integer'),
                 'biginteger'    => array('name' => 'bigint'),
                 'float'         => array('name' => 'float'),
-                'decimal'       => array('name' => 'decimal', 'scale' => 10, 'precision' => 0),
+                'decimal'       => array('name' => 'decimal', 'scale' => 0, 'precision' => 10),
                 'datetime'      => array('name' => 'timestamp'),
                 'timestamp'     => array('name' => 'timestamp'),
                 'time'          => array('name' => 'time'),


### PR DESCRIPTION
Resolves error where the precision value must be greater than the scale
value in MySQL. Have also updated PostgreSQL adaptor for consistency.

Detail of the error can be found at
http://dev.mysql.com/doc/refman/5.0/en/error-messages-server.html#error_
er_m_bigger_than_d
