### PR TITLE
[FEATURE] Added support for tinytext type to MySQL adapter

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -105,6 +105,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'primary_key'   => array('name' => 'integer', 'limit' => 11, 'null' => false),
                 'string'        => array('name' => "varchar", 'limit' => 255),
                 'text'          => array('name' => "text"),
+                'tinytext'		=> array('name' => "tinytext"),
                 'mediumtext'    => array('name' => 'mediumtext'),
                 'integer'       => array('name' => "int", 'limit' => 11),
                 'smallinteger'  => array('name' => "smallint"),

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -105,6 +105,7 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'primary_key'   => array('name' => 'serial'),
                 'string'        => array('name' => 'varchar', 'limit' => 255),
                 'text'          => array('name' => 'text'),
+                'tinytext'		=> array('name' => 'text'),
                 'mediumtext'    => array('name' => 'text'),
                 'integer'       => array('name' => 'integer'),
                 'smallinteger'  => array('name' => 'smallint'),

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -206,6 +206,9 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
 
         $expected = "`adapter` enum('mysql','pgsql','ha\'xor')";
         $this->assertEquals($expected, $this->adapter->column_definition("adapter", "enum", array('values' => array('mysql', 'pgsql', "ha'xor"))));
+
+        $expected = "`age` tinytext";
+        $this->assertEquals($expected, $this->adapter->column_definition("age", "tinytext"));
     }//test_column_definition
 
     /**

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -226,6 +226,9 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
 
         $expected = '"weight" bigint';
         $this->assertEquals($expected, $this->adapter->column_definition("weight", "biginteger"));
+
+        $expected = '"age" text';
+        $this->assertEquals($expected, $this->adapter->column_definition("age", "tinytext"));
     }
 
     /**


### PR DESCRIPTION
Hello, 

I've added support for missing tinytext column type in MySQL adapter.

To use tinytext column type, use 'tinytext' as type value when creating
or updating a column.

Eg. $this->add_column('table', 'column', 'tinytext');

PostgreSQL has no equivalent for tinytext, so falls back to text type
when 'tinytext' is used.

MySQL 5.0 documentation for the tinytext column type can be found at
http://dev.mysql.com/doc/refman/5.0/en/blob.html

Thanks, 
SB
