### PR TITLE
Rename db:schema to db:structure and replaced db:schema to also dump the migration versions

### DIFF
--- a/lib/Ruckusing/Adapter/Interface.php
+++ b/lib/Ruckusing/Adapter/Interface.php
@@ -53,6 +53,13 @@ interface Ruckusing_Adapter_Interface
     public function native_database_types();
 
     /**
+     * structure
+     *
+     * @return void
+     */
+    public function structure($output_file);
+
+    /**
      * schema
      *
      * @return void

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -259,7 +259,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
     }
 
     /**
-     * Dump the complete schema of the DB. This is really just all of the
+     * Dump the complete structure of the DB. This is really just all of the
      * CREATE TABLE statements for all of the tables in the DB.
      * NOTE: this does NOT include any INSERT statements or the actual data
      * (that is, this method is NOT a replacement for mysqldump)
@@ -268,7 +268,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
      *
      * @return int|FALSE
      */
-    public function schema($output_file)
+    public function structure($output_file)
     {
         $final = "";
         $views = '';
@@ -287,6 +287,63 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 if (count($row) == 2) {
                     if (isset($row['Create Table'])) {
                         $final .= $row['Create Table'] . ";\n\n";
+                    } elseif (isset($row['Create View'])) {
+                        $views .= $row['Create View'] . ";\n\n";
+                    }
+                }
+            }
+        }
+        $data = $final.$views;
+
+        return file_put_contents($output_file, $data, LOCK_EX);
+    }
+
+    /**
+     * Dump the complete structure and the versions of the migratiosn of the DB.
+     * This is really just all of the CREATE TABLE statements for all of the
+     * tables in the DB.
+     * NOTE: this does NOT include any INSERT statements other than for the 
+     * migrations table.
+     * (that is, this method is NOT a replacement for mysqldump)
+     *
+     * @param string $output_file the filepath to output to
+     *
+     * @return int|FALSE
+     */
+    public function schema($output_file)
+    {
+        $final = "/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;\n\n";
+        $views = '';
+        $this->load_tables(true);
+        foreach ($this->_tables as $tbl => $idx) {
+
+            if ($tbl == RUCKUSING_TS_SCHEMA_TBL_NAME) {
+                $migrations_schema = $this->query("SHOW CREATE TABLE " . RUCKUSING_TS_SCHEMA_TBL_NAME . ";")[0]['Create Table'].";\n\n";
+                $migration_versions = $this->query("SELECT * FROM " . RUCKUSING_TS_SCHEMA_TBL_NAME . ";");
+
+                $final .= $migrations_schema;
+                $final .= "LOCK TABLES `" . RUCKUSING_TS_SCHEMA_TBL_NAME . "` WRITE;\n\n";
+
+                $final .= "INSERT IGNORE INTO `" . RUCKUSING_TS_SCHEMA_TBL_NAME . "` (`version`)\nVALUES\n";
+
+                foreach ($migration_versions as $row) {
+                    $final .= "    ('" . $row['version'] . "'),\n";
+                }
+                $final = rtrim($final, ",\n");
+                $final .= ";\n\n";
+
+                $final .= "UNLOCK TABLES;\n\n";
+                continue;
+            }
+
+            $stmt = sprintf("SHOW CREATE TABLE %s", $this->identifier($tbl));
+            $result = $this->query($stmt);
+
+            if (is_array($result) && count($result) == 1) {
+                $row = $result[0];
+                if (count($row) == 2) {
+                    if (isset($row['Create Table'])) {
+                        $final .= preg_replace("/AUTO_INCREMENT=([0-9]*)/", "AUTO_INCREMENT=1", $row['Create Table']) . ";\n\n";
                     } elseif (isset($row['Create View'])) {
                         $views .= $row['Create View'] . ";\n\n";
                     }

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -316,8 +316,29 @@ SQL;
      *
      * @return int|FALSE
      */
+    public function structure($output_file)
+    {
+        $command = sprintf("pg_dump -U %s -Fp -s -f '%s' %s",
+                $this->db_info['user'],
+                $output_file,
+                $this->db_info['database']
+        );
+
+        return system($command);
+    }
+
+    /**
+     * Dump the complete schema of the DB. This is really just all of the
+     * CREATE TABLE statements for all of the tables in the DB.
+     * NOTE: this does NOT include any INSERT statements or the actual data
+     *
+     * @param string $output_file the filepath to output to
+     *
+     * @return int|FALSE
+     */
     public function schema($output_file)
     {
+        //Can't really do this properly as I don't know PgSQL
         $command = sprintf("pg_dump -U %s -Fp -s -f '%s' %s",
                 $this->db_info['user'],
                 $output_file,

--- a/lib/Task/Db/Structure.php
+++ b/lib/Task/Db/Structure.php
@@ -21,7 +21,7 @@
  * @author   Cody Caughlan <codycaughlan % gmail . com>
  * @link      https://github.com/ruckus/ruckusing-migrations
  */
-class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Interface
+class Task_Db_Structure extends Ruckusing_Task_Base implements Ruckusing_Task_Interface
 {
     /**
      * Current Adapter
@@ -38,11 +38,11 @@ class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Inter
     private $_return = '';
 
     /**
-     * Creates an instance of Task_DB_Schema
+     * Creates an instance of Task_DB_Structure
      *
      * @param Ruckusing_Adapter_Base $adapter The current adapter being used
      *
-     * @return Task_DB_Schema
+     * @return Task_DB_Structure
      */
     public function __construct($adapter)
     {
@@ -58,12 +58,12 @@ class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Inter
     public function execute($args)
     {
         $this->_return .= "Started: " . date('Y-m-d g:ia T') . "\n\n";
-        $this->_return .= "[db:schema]: \n";
+        $this->_return .= "[db:structure]: \n";
 
         //write to disk
-        $schema_file = $this->db_dir() . '/schema.txt';
-        $schema = $this->_adapter->schema($schema_file);
-        $this->_return .= "\tSchema written to: $schema_file\n\n";
+        $structure_file = $this->db_dir() . '/structure.txt';
+        $structure = $this->_adapter->structure($structure_file);
+        $this->_return .= "\tStructure written to: $structure_file\n\n";
         $this->_return .= "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
 
         return $this->_return;
@@ -79,7 +79,7 @@ class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Inter
         // create the db directory if it doesnt exist
         $db_directory = $this->get_framework()->db_directory();
         if (!is_dir($db_directory)) {
-            $this->_return .= sprintf("\n\tDB Schema directory (%s doesn't exist, attempting to create.\n", $db_directory);
+            $this->_return .= sprintf("\n\tDB Structure directory (%s doesn't exist, attempting to create.\n", $db_directory);
             if (mkdir($db_directory, 0755, true) === FALSE) {
                 $this->_return .= sprintf("\n\tUnable to create migrations directory at %s, check permissions?\n", $db_directory);
             } else {
@@ -90,7 +90,7 @@ class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Inter
         //check to make sure our destination directory is writable
         if (!is_writable($db_directory)) {
             throw new Ruckusing_Exception(
-                    "ERROR: DB Schema directory '"
+                    "ERROR: DB Structure directory '"
                     . $db_directory
                     . "' is not writable by the current user. Check permissions and try again.\n",
                     Ruckusing_Exception::INVALID_DB_DIR
@@ -109,12 +109,12 @@ class Task_Db_Schema extends Ruckusing_Task_Base implements Ruckusing_Task_Inter
     {
         $output =<<<USAGE
 
-\tTask: db:schema
+\tTask: db:structure
 
 \tIt can be beneficial to get a dump of the DB in raw SQL format which represents
 \tthe current version.
 
-\tNote: This dump only contains the actual schema (e.g. the DML needed to
+\tNote: This dump only contains the actual structure (e.g. the DML needed to
 \treconstruct the DB), but not any actual data.
 
 \tIn MySQL terms, this task would not be the same as running the mysqldump command


### PR DESCRIPTION
To be able to really use migrations in a way that makes sense, you need to know in what version the
database was when you made the schema dump so anyone can run a copy of the output and be up and
running. Otherwise, the database doesn't know in what version it is and will always try to run
all the migrations again which isn't working well.

For those that still only want the structure, there is now a db:structure command instead.

I will happily refactor the wiki once/if the pull-request is merged.

Also, I don't know how to make the Postgres part so if someone feels compelled to fix that part, I would be so grateful.