### PR TITLE
Add shortcut timestamps in table creation

### DIFF
--- a/lib/Ruckusing/Adapter/Interface.php
+++ b/lib/Ruckusing/Adapter/Interface.php
@@ -201,5 +201,23 @@ interface Ruckusing_Adapter_Interface
      * @return boolean
      */
     public function add_index($table_name, $column_name, $options = array());
+    
+    /**
+     * add timestamps
+     *
+     * @param string $table_name  The table name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name);
+    
+    /**
+     * remove timestamps
+     *
+     * @param string $table_name  The table name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name);
 
 }

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -814,7 +814,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             );
         }
         $updated_at = $this->add_column($table_name, "updated_at", "timestamp", array("null" => false));
-        $created_at = $this->add_column($table_name, "created_at", "timestamp");
+        $created_at = $this->add_column($table_name, "created_at", "datetime");
 
         return $created_at && $updated_at;
     }

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -813,8 +813,8 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                     Ruckusing_Exception::INVALID_ARGUMENT
             );
         }
-        $created_at = $this->add_column($table_name, "created_at", "datetime", array("null" => false));
-        $updated_at = $this->add_column($table_name, "updated_at", "datetime", array("null" => false));
+        $updated_at = $this->add_column($table_name, "updated_at", "timestamp", array("null" => false));
+        $created_at = $this->add_column($table_name, "created_at", "timestamp");
 
         return $created_at && $updated_at;
     }
@@ -834,8 +834,8 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                     Ruckusing_Exception::INVALID_ARGUMENT
             );
         }
-        $created_at = $this->remove_column($table_name, "created_at", "datetime", array("null" => false));
-        $updated_at = $this->remove_column($table_name, "updated_at", "datetime", array("null" => false));
+        $updated_at = $this->remove_column($table_name, "updated_at");
+        $created_at = $this->remove_column($table_name, "created_at");
 
         return $created_at && $updated_at;
     }

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -797,6 +797,48 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
 
         return $this->execute_ddl($sql);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name  the table name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->add_column($table_name, "created_at", "datetime", array("null" => false));
+        $updated_at = $this->add_column($table_name, "updated_at", "datetime", array("null" => false));
+
+        return $created_at && $updated_at;
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name  the table name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->remove_column($table_name, "created_at", "datetime", array("null" => false));
+        $updated_at = $this->remove_column($table_name, "updated_at", "datetime", array("null" => false));
+
+        return $created_at && $updated_at;
+    }
 
     /**
      * Check an index

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -1116,6 +1116,9 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             if (empty($db_info['socket'])) {
                 $db_info['socket'] = @ini_get('mysqli.default_socket');
             }
+            if (empty($db_info['charset'])) {
+                $db_info['charset'] = "utf8";
+            }
             $this->conn = new mysqli($db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']); //db name leaved for selection
             if ($this->conn->connect_error) {
                 throw new Ruckusing_Exception(
@@ -1126,6 +1129,12 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             if (!$this->conn->select_db($db_info['database'])) {
                 throw new Ruckusing_Exception(
                         "\n\nCould not select the DB " . $db_info['database'] . ", check permissions on host " . $db_info['host'] . " \n\n",
+                        Ruckusing_Exception::INVALID_CONFIG
+                );
+            }
+            if (!$this->conn->set_charset($db_info['charset'])) {
+                throw new Ruckusing_Exception(
+                        "\n\nCould not set charset " . $db_info['charset'] . " \n\n",
                         Ruckusing_Exception::INVALID_CONFIG
                 );
             }

--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -169,6 +169,16 @@ class Ruckusing_Adapter_MySQL_TableDefinition
 
         $this->_columns[] = $column;
     }//column
+    
+    /**
+     * Shortcut to create timestamps columns (created_at, updated_at)
+     *    
+     */
+    public function timestamps()
+    {
+      $this->column("created_at", "datetime", array("null" => false));
+      $this->column("updated_at", "datetime", array("null" => false));
+    }
 
     /**
      * Get all primary keys

--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -176,8 +176,8 @@ class Ruckusing_Adapter_MySQL_TableDefinition
      */
     public function timestamps()
     {
-      $this->column("created_at", "datetime", array("null" => false));
-      $this->column("updated_at", "datetime", array("null" => false));
+      $this->column($table_name, "updated_at", "timestamp", array("null" => false));
+      $this->column($table_name, "created_at", "timestamp");
     }
 
     /**

--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -177,7 +177,7 @@ class Ruckusing_Adapter_MySQL_TableDefinition
     public function timestamps()
     {
       $this->column($table_name, "updated_at", "timestamp", array("null" => false));
-      $this->column($table_name, "created_at", "timestamp");
+      $this->column($table_name, "created_at", "datetime");
     }
 
     /**

--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -176,8 +176,8 @@ class Ruckusing_Adapter_MySQL_TableDefinition
      */
     public function timestamps()
     {
-      $this->column($table_name, "updated_at", "timestamp", array("null" => false));
-      $this->column($table_name, "created_at", "datetime");
+      $this->column("updated_at", "timestamp", array("null" => false));
+      $this->column("created_at", "datetime");
     }
 
     /**

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -959,6 +959,48 @@ SQL;
 
         return $this->execute_ddl($sql);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name  the table name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->add_column($table_name, "created_at", "datetime", array("null" => false));
+        $updated_at = $this->add_column($table_name, "updated_at", "datetime", array("null" => false));
+
+        return $created_at && $updated_at;
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name  the table name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->remove_column($table_name, "created_at", "datetime", array("null" => false));
+        $updated_at = $this->remove_column($table_name, "updated_at", "datetime", array("null" => false));
+
+        return $created_at && $updated_at;
+    }
 
     /**
      * Check an index

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -996,8 +996,8 @@ SQL;
                     Ruckusing_Exception::INVALID_ARGUMENT
             );
         }
-        $created_at = $this->remove_column($table_name, "created_at", "datetime", array("null" => false));
-        $updated_at = $this->remove_column($table_name, "updated_at", "datetime", array("null" => false));
+        $created_at = $this->remove_column($table_name, "created_at");
+        $updated_at = $this->remove_column($table_name, "updated_at");
 
         return $created_at && $updated_at;
     }

--- a/lib/Ruckusing/Adapter/PgSQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/PgSQL/TableDefinition.php
@@ -160,6 +160,16 @@ class Ruckusing_Adapter_PgSQL_TableDefinition extends Ruckusing_Adapter_TableDef
 
         $this->_columns[] = $column;
     }//column
+    
+    /**
+     * Shortcut to create timestamps columns (created_at, updated_at)
+     *    
+     */
+    public function timestamps()
+    {
+      $this->column("created_at", "datetime", array("null" => false));
+      $this->column("updated_at", "datetime", array("null" => false));
+    }
 
     /**
      * Get all primary keys

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -216,6 +216,30 @@ class Ruckusing_Migration_Base
     {
         return $this->_adapter->remove_index($table_name, $column_name, $options);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name  the name of the table
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name)
+    {
+        return $this->_adapter->add_timestamps($table_name);
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name  the name of the table
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name)
+    {
+        return $this->_adapter->remove_timestamps($table_name);
+    }
 
     /**
      * Create a table

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -444,6 +444,58 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(false, $this->adapter->has_index("users", "name", array('name' => 'my_special_index')) );
         $this->remove_table('users');
     }
+    
+    /**
+     * test add timestamps
+     */
+    public function test_add_timestamps()
+    {
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `users` ( name varchar(20) );");
+
+        $col = $this->adapter->column_info("users", "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $this->adapter->add_timestamps("users");
+        
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+        
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+
+        $this->remove_table('users');
+    }
+    
+    /**
+     * test remove timestamps
+     */
+    public function test_remove_timestamps()
+    {
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `users` ( name varchar(20), created_at datetime not null, updated_at datetime not null );");
+        
+        //verify they exists
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+
+        //drop them
+        $this->adapter->remove_timestamps("users");
+
+        //verify they does not exist
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals(null, $col);
+        
+        $this->remove_table('users');
+    }
 
     /**
      * test string quoting

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -417,6 +417,58 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
 
         $this->drop_table('users');
     }
+    
+    /**
+     * test add timestamps
+     */
+    public function test_add_timestamps()
+    {
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `users` ( name varchar(20) );");
+
+        $col = $this->adapter->column_info("users", "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $this->adapter->add_timestamps("users");
+        
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+        
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+
+        $this->remove_table('users');
+    }
+    
+    /**
+     * test remove timestamps
+     */
+    public function test_remove_timestamps()
+    {
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `users` ( name varchar(20), created_at datetime not null, updated_at datetime not null );");
+        
+        //verify they exists
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+
+        //drop them
+        $this->adapter->remove_timestamps("users");
+
+        //verify they does not exist
+        $col = $this->adapter->column_info("users", "created_at");
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info("users", "updated_at");
+        $this->assertEquals(null, $col);
+        
+        $this->remove_table('users');
+    }
 
     /**
      * test multi column index


### PR DESCRIPTION
To follow Rails philosophy, here is methods to ease adding timestamps columns into a table. 
http://guides.rubyonrails.org/migrations.html#migration-overview

Still to do add_timestamps and remove_timestamps.