### PR TITLE
Added uuid column type for MySQL and PgSQL adapters.

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -105,10 +105,10 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'primary_key'   => array('name' => 'integer', 'limit' => 11, 'null' => false),
                 'string'        => array('name' => "varchar", 'limit' => 255),
                 'text'          => array('name' => "text"),
-                'tinytext'		=> array('name' => "tinytext"),
+                'tinytext'      => array('name' => "tinytext"),
                 'mediumtext'    => array('name' => 'mediumtext'),
                 'integer'       => array('name' => "int", 'limit' => 11),
-                'tinyinteger'	=> array('name' => "tinyint"),
+                'tinyinteger'  	=> array('name' => "tinyint"),
                 'smallinteger'  => array('name' => "smallint"),
                 'mediuminteger'	=> array('name' => "mediumint"),
                 'biginteger'    => array('name' => "bigint"),
@@ -119,11 +119,12 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'time'          => array('name' => "time"),
                 'date'          => array('name' => "date"),
                 'binary'        => array('name' => "blob"),
-		'tinybinary'    => array('name' => "tinyblob"),
-		'mediumbinary'  => array('name' => "mediumblob"),
-		'longbinary'    => array('name' => "longblob"),
+		            'tinybinary'    => array('name' => "tinyblob"),
+		            'mediumbinary'  => array('name' => "mediumblob"),
+		            'longbinary'    => array('name' => "longblob"),
                 'boolean'       => array('name' => "tinyint", 'limit' => 1),
-                'enum'          => array('name' => "enum", 'values' => array())
+                'enum'          => array('name' => "enum", 'values' => array()),
+                'uuid'          => array('name' => "char", 'limit' => 36),
         );
 
         return $types;

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -105,10 +105,10 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'primary_key'   => array('name' => 'serial'),
                 'string'        => array('name' => 'varchar', 'limit' => 255),
                 'text'          => array('name' => 'text'),
-                'tinytext'		=> array('name' => 'text'),
+                'tinytext'      => array('name' => 'text'),
                 'mediumtext'    => array('name' => 'text'),
                 'integer'       => array('name' => 'integer'),
-                'tinyinteger'	=> array('name' => 'smallint'),
+                'tinyinteger'	  => array('name' => 'smallint'),
                 'smallinteger'  => array('name' => 'smallint'),
                 'mediuminteger' => array('name' => 'integer'),
                 'biginteger'    => array('name' => 'bigint'),
@@ -119,11 +119,12 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 'time'          => array('name' => 'time'),
                 'date'          => array('name' => 'date'),
                 'binary'        => array('name' => 'bytea'),
-		'tinybinary'    => array('name' => "bytea"),
-		'mediumbinary'  => array('name' => "bytea"),
-		'longbinary'    => array('name' => "bytea"),
+		            'tinybinary'    => array('name' => "bytea"),
+		            'mediumbinary'  => array('name' => "bytea"),
+		            'longbinary'    => array('name' => "bytea"),
                 'boolean'       => array('name' => 'boolean'),
-                'tsvector'      => array('name' => 'tsvector')
+                'tsvector'      => array('name' => 'tsvector'),
+                'uuid'          => array('name' => 'uuid'),
         );
 
         return $types;


### PR DESCRIPTION
I hope this is helpful. Needed a quick/easy way to specify UUID columns. For MySQL, I would have used the char(36) type, but "char" type does not yet exist in MySQL adapter's native_database_types() method.
