### PR TITLE
Proposal to remove travis test for php 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.2
   - 5.3
   - 5.4
+  - 5.5
 
 before_script:
   - mysql -uroot < tests/test.sql


### PR DESCRIPTION
As the before_script call now installs composer, this loses travis support for 5.2 already, and so travis tests have been failing since.
I think either we remove 5.2 from here like in this commit, or we remove the composer install, or if needed a hybrid approach where we have a bash script run as the before_script that checks the php version, and only for 5.3+ installs composer. Though i guess it depends on how important 5.2 support is to the project.

(also added php 5.5 to test on)
