### PR TITLE
Made utf8 as default CHARSET for mySql

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -216,7 +216,7 @@ class Ruckusing_Adapter_MySQL_TableDefinition
         if(isset($this->_adapter->db_info['charset'])){
             $opt_str .= " DEFAULT CHARSET=".$this->_adapter->db_info['charset'];
         } else {
-            $opt_str .= " DEFAULT CHARSET=latin1";
+            $opt_str .= " DEFAULT CHARSET=utf8";
         }
 
         $close_sql = sprintf(") %s;",$opt_str);


### PR DESCRIPTION
On several points utf8 was made the default charset for mySql, this is a follow-up for that
