### PR TITLE
Warn if migrations directory not writable instead of exception

### DIFF
--- a/lib/Task/Db/Migrate.php
+++ b/lib/Task/Db/Migrate.php
@@ -332,12 +332,7 @@ class Task_Db_Migrate extends Ruckusing_Task_Base implements Ruckusing_Task_Inte
             }
             //check to make sure our destination directory is writable
             if (!is_writable($path)) {
-                throw new Ruckusing_Exception(
-                    "ERROR: Migrations directory '"
-                    . $path
-                    . "' is not writable by the current user. Check permissions and try again.\n",
-                    Ruckusing_Exception::INVALID_MIGRATION_DIR
-                );
+                $this->_return .= sprintf("\n\tMigrations directory (%s) is not writable. Migrations can be applied, bot not created.", $path);
             }
         }
     }


### PR DESCRIPTION
Use case:

* Wordpress plugin, when migrations only applied to DB and NOT created.
* All creation is locally in normal DEV environment.
* Loggin (through) settings into PHP current /tmp dir, into `md5(__FILE__)`