### PR TITLE
Refactor split_query method

### DIFF
--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -232,28 +232,36 @@ class Ruckusing_Migration_Base
 
     /**
      * Split up multiple sql queries from a single query string
-     * @link   http://stackoverflow.com/questions/4001797/how-to-break-queries-using-regex-in-php
+     *
      * @param  string $query The query to be split
      * @return array Each query string found
      */
     protected function split_query($query)
     {
-        $open = false;
-        $buffer = null;
-        $parts = array();
-        for($i = 0, $l = strlen($query); $i < $l; $i++) {
-            if ($query[$i] == ';' && !$open) {
-                $parts[] = trim($buffer);
-                $buffer = null;
+        $res = array();
+        $buffer = '';
+        $lines = preg_split("/\r\n|\n|\r/", $query);
+        foreach ($lines as $line) {
+            $t_line = trim($line);
+            // Skip it if it's a comment
+            if (substr($t_line, 0, 2) == '--' || $t_line == '') {
                 continue;
             }
-            if ($query[$i] == "'") {
-                $open = ($open) ? false: true;
+
+            $buffer .= $line;
+
+            // If it has a semicolon at the end, it's the end of the query
+            if (substr($t_line, -1, 1) == ';') {
+                $res[] = $buffer;
+                $buffer = '';
             }
-            $buffer .= $query[$i];
         }
-        if ($buffer) $parts[] = trim($buffer);
-        return $parts;
+
+        if ($buffer) {
+            $res[] = $buffer;
+        }
+
+        return $res;
     }
 
     /**
@@ -270,7 +278,7 @@ class Ruckusing_Migration_Base
         foreach($queries as $query_s) {
             $query_s = trim($query_s);
             if (!empty($query_s)) {
-                $result = $this->_adapter->query($query_s.';');
+                $result = $this->_adapter->query($query_s);
             }
         }
         return $result;

--- a/tests/unit/BaseMigrationTest.php
+++ b/tests/unit/BaseMigrationTest.php
@@ -123,8 +123,29 @@ create table `adminsession` (
         $rows = $this->adapter->select_all('SELECT * FROM demo');
         $this->assertEquals(2, count($rows));
 
+        // test multiple queries with a single quote inside query
+        $base->execute("
+            DROP TABLE IF EXISTS `demo2`;
+            CREATE TABLE `demo2` (
+              `id` INT(11) NOT NULL AUTO_INCREMENT,
+              `name` VARCHAR(100) NOT NULL,
+              PRIMARY KEY (`id`)
+            );
+
+            -- comment with ' quote
+            INSERT INTO demo2(id, name) VALUES(1,'A;A');
+            INSERT INTO demo2(id, name) VALUES(2,'b\\'b');
+            INSERT INTO demo2(id, name) VALUES(3,'cc')
+        ");
+        $rows = $this->adapter->select_all('SELECT * FROM demo2');
+        $this->assertEquals(3, count($rows));
+
         // cleanup
-        $base->execute("DROP TABLE `admin`; DROP TABLE `adminsession`; DROP TABLE `demo`;");
-        
+        $base->execute("
+            DROP TABLE `admin`;
+            DROP TABLE `adminsession`;
+            DROP TABLE `demo`;
+            DROP TABLE `demo2`;
+        ");
     }
 }


### PR DESCRIPTION
I see the potential error in Ruckusing_Migration_Base::split_query() method. If your query has a single quote in string, it may not be executed. Please see the diff in BaseMigrationTest for example.

I refactor method to fix this error. But now multiple queries in one line is not supported. As for me this is not critical because all of dumps I know (mysqldump, phpmyadmin, adminer) have not more then one query per line.

I think that is even better to realize multi_query method for each adapter and use it in "execute" method. For example for mysql we can use native multi_query method which is more reliable than our own sql parser.