### PR TITLE
Add timestamp shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The available methods are (brief list below, with detailed usageg further down):
 * `remove_column`
 * `rename_column`
 * `change_column`
+* `add_timestamps`
 
 ## Index-level operations
 * `add_index`
@@ -312,7 +313,7 @@ Database columns can be renamed (assuming the underlying RDMBS/adapter supports 
     $this->rename_column("users", "first_name", "fname");
 ```
 
-## Modifying an existing column
+### Modifying an existing column
 The type, defaults or `NULL` support for existing columns can be modified. If you want to just rename a column then use the `rename_column` method. This method takes a generalized type for the column's type and also an array of options which affects the column definition. For the available types and options, see the documentation on adding new columns, AddingColumns.
 
 
@@ -330,6 +331,28 @@ The type, defaults or `NULL` support for existing columns can be modified. If yo
 **Example A:** From the `users` table, change the length of the `first_name` column to 128.
 ```php
     $this->change_column("users", "first_name", "string", array('limit' => 128) );
+```
+
+### Add timestamps columns
+We often need colunmns to timestamp the _created at_ and _updated at_ operations. This convenient method is here to easily generate them for you.
+
+**Method Call:**`add_timestamps`
+
+**Arguments:**
+  `table_name`: The name of the table to which the columns will be added
+  
+  `created_name`: The desired of the _created at_ column, be default `created_at`
+  
+  `updated_name`:  The desired of the _updated at_ column, be default `updated_at`
+  
+**Exemple A:** Add timestamps columns to `users` table.
+```php
+    $this->add_timestamps("users");
+```
+
+**Exemple B:** Add timestamps columns to `users` table with `created` and `updated` column names.
+```php
+    $this->add_timestamps("users", "created", "updated");
 ```
 
 ## Index-level operations

--- a/lib/Ruckusing/Adapter/Interface.php
+++ b/lib/Ruckusing/Adapter/Interface.php
@@ -203,6 +203,28 @@ interface Ruckusing_Adapter_Interface
     public function add_index($table_name, $column_name, $options = array());
 
     /**
+     * add timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name, $created_column_name, $updated_column_name);
+
+    /**
+     * remove timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name, $created_column_name, $updated_column_name);
+
+    /**
      * Wrapper to execute a query
      *
      * @param string $query query to run

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -808,6 +808,76 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
 
         return $this->execute_ddl($sql);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($created_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing created at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($updated_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing updated at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->add_column($table_name, $created_column_name, "datetime");
+        $updated_at = $this->add_column($table_name, $updated_column_name, "timestamp", array("null" => false, 'default' => 'CURRENT_TIMESTAMP', 'extra' => 'ON UPDATE CURRENT_TIMESTAMP'));
+
+        return $created_at && $updated_at;
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($created_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing created at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($updated_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing updated at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $updated_at = $this->remove_column($table_name, $created_column_name);
+        $created_at = $this->remove_column($table_name, $updated_column_name);
+
+        return $created_at && $updated_at;
+    }
 
     /**
      * Check an index
@@ -1039,6 +1109,8 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 $default_format = '%d';
             } elseif (is_bool($options['default'])) {
                 $default_format = "'%d'";
+            } elseif ($options['default'] == 'CURRENT_TIMESTAMP') {
+                $default_format = "%s";
             } else {
                 $default_format = "'%s'";
             }
@@ -1052,6 +1124,9 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
         }
         if (array_key_exists('comment', $options)) {
             $sql .= sprintf(" COMMENT '%s'", $this->quote_string($options['comment']));
+        }
+        if (array_key_exists('extra', $options)) {
+            $sql .= sprintf(" %s", $this->quote_string($options['extra']));
         }
         if (array_key_exists('after', $options)) {
             $sql .= sprintf(" AFTER %s", $this->identifier($options['after']));

--- a/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/MySQL/TableDefinition.php
@@ -172,6 +172,19 @@ class Ruckusing_Adapter_MySQL_TableDefinition
     }//column
 
     /**
+     * Shortcut to create timestamps columns (default created_at, updated_at)
+     *
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *    
+     */
+    public function timestamps($created_column_name = "created_at", $updated_column_name = "updated_at")
+    {
+        $this->column($created_column_name, "datetime");
+        $this->column($updated_column_name, "timestamp", array("null" => false, 'default' => 'CURRENT_TIMESTAMP', 'extra' => 'ON UPDATE CURRENT_TIMESTAMP'));
+    }
+
+    /**
      * Get all primary keys
      *
      * @return string

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -969,7 +969,77 @@ SQL;
 
         return $this->execute_ddl($sql);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($created_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing created at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($updated_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing updated at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->add_column($table_name, $created_column_name, "datetime", array("null" => false));
+        $updated_at = $this->add_column($table_name, $updated_column_name, "datetime", array("null" => false));
 
+        return $created_at && $updated_at;
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name          The table name
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        if (empty($table_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing table name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($created_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing created at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        if (empty($updated_column_name)) {
+            throw new Ruckusing_Exception(
+                    "Missing updated at column name parameter",
+                    Ruckusing_Exception::INVALID_ARGUMENT
+            );
+        }
+        $created_at = $this->remove_column($table_name, $created_column_name);
+        $updated_at = $this->remove_column($table_name, $updated_column_name);
+
+        return $created_at && $updated_at;
+    }
+    
     /**
      * Check an index
      *

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -864,7 +864,9 @@ SQL;
                 $data['null'] = $result['attnotnull'] == 'f';
                 $data['default'] = $result['adsrc'];
             }
-
+            else{
+              $data = null;
+            }
             return $data;
         } catch (Exception $e) {
             return null;

--- a/lib/Ruckusing/Adapter/PgSQL/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/PgSQL/TableDefinition.php
@@ -161,7 +161,20 @@ class Ruckusing_Adapter_PgSQL_TableDefinition extends Ruckusing_Adapter_TableDef
 
         $this->_columns[] = $column;
     }//column
-
+    
+    /**
+     * Shortcut to create timestamps columns (default created_at, updated_at)
+     *
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *    
+     */
+    public function timestamps($created_column_name = "created_at", $updated_column_name = "updated_at")
+    {
+        $this->column($created_column_name, "datetime", array("null" => false));
+        $this->column($updated_column_name, "datetime", array("null" => false));
+    }
+    
     /**
      * Get all primary keys
      *

--- a/lib/Ruckusing/Adapter/Sqlite3/Base.php
+++ b/lib/Ruckusing/Adapter/Sqlite3/Base.php
@@ -557,6 +557,28 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
     }
 
     /**
+     * @param $table_name
+     * @param $created_column_name
+     * @param $updated_column_name
+     * @return boolean
+     */
+    public function add_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        $this->log_unsupported_feature(__FUNCTION__);
+    }
+
+   /**
+     * @param $table_name
+     * @param $created_column_name
+     * @param $updated_column_name
+     * @return boolean
+     */
+    public function remove_timestamps($table_name, $created_column_name, $updated_column_name)
+    {
+        $this->log_unsupported_feature(__FUNCTION__);
+    }
+
+    /**
      * @param $type
      * @param $options
      * @param bool $performing_change
@@ -575,6 +597,8 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
                     $default_format = '%d';
                 } elseif (is_bool($options['default'])) {
                     $default_format = "'%d'";
+                } elseif ($options['default'] == 'CURRENT_TIMESTAMP') {
+                    $default_format = "%s";
                 } else {
                     $default_format = "'%s'";
                 }
@@ -584,6 +608,9 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
 
             if (array_key_exists('null', $options) && $options['null'] === false) {
                 $sql .= " NOT NULL";
+            }
+            if (array_key_exists('extra', $options)) {
+                $sql .= sprintf(" %s", $this->quote_string($options['extra']));
             }
         }
         return $sql;

--- a/lib/Ruckusing/Adapter/Sqlite3/TableDefinition.php
+++ b/lib/Ruckusing/Adapter/Sqlite3/TableDefinition.php
@@ -198,6 +198,15 @@ class Ruckusing_Adapter_Sqlite3_TableDefinition extends Ruckusing_Adapter_TableD
     }
 
     /**
+     * 
+     */
+    public function timestamps($created_column_name = "created_at", $updated_column_name = "updated_at")
+    {
+        $this->column($created_column_name, "datetime", array("null" => false, 'default' => 'CURRENT_TIMESTAMP'));
+        $this->column($updated_column_name, "datetime", array("null" => false, 'default' => 'CURRENT_TIMESTAMP'));
+    }
+
+    /**
      * @return string
      */
     private function keys()

--- a/lib/Ruckusing/Migration/Base.php
+++ b/lib/Ruckusing/Migration/Base.php
@@ -218,6 +218,34 @@ class Ruckusing_Migration_Base
     {
         return $this->_adapter->remove_index($table_name, $column_name, $options);
     }
+    
+    /**
+     * Add timestamps
+     *
+     * @param string $table_name  the name of the table
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function add_timestamps($table_name, $created_column_name = "created_at", $updated_column_name = "updated_at")
+    {
+        return $this->_adapter->add_timestamps($table_name, $created_column_name, $updated_column_name);
+    }
+    
+    /**
+     * Remove timestamps
+     *
+     * @param string $table_name  the name of the table
+     * @param string $created_column_name Created at column name
+     * @param string $updated_column_name Updated at column name
+     *
+     * @return boolean
+     */
+    public function remove_timestamps($table_name, $created_column_name = "created_at", $updated_column_name = "updated_at")
+    {
+        return $this->_adapter->remove_timestamps($table_name, $created_column_name, $updated_column_name);
+    }
 
     /**
      * Create a table

--- a/tests/unit/MySQLAdapterTest.php
+++ b/tests/unit/MySQLAdapterTest.php
@@ -446,6 +446,152 @@ class MySQLAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * test add timestamps
+     */
+    public function test_add_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `$table_name` ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $bm->add_timestamps($table_name);
+        
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+        
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+        $this->assertEquals('timestamp', $col['type'] );
+
+        $this->remove_table($table_name);
+    }
+
+    /**
+     * test remove timestamps
+     */
+    public function test_remove_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `$table_name` ( name varchar(20), created_at datetime not null, updated_at datetime not null );");
+        
+        //verify they exists
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+
+        //drop them
+        $bm->remove_timestamps($table_name);
+
+        //verify they does not exist
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals(null, $col);
+        
+        $this->remove_table($table_name);
+    }
+
+    /**
+     * test add empty colmun names timestamps
+     */
+    public function test_add_empty_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `$table_name` ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        try{
+          //add timestamps
+          $bm->add_timestamps($table_name, "", "");
+        } catch (Ruckusing_Exception $exception) {
+            if (Ruckusing_Exception::INVALID_ARGUMENT == $exception->getCode()) {
+                $this->remove_table($table_name);
+                return;
+            }
+        }
+        $this->fail('Expected to raise & catch Ruckusing_Exception::INVALID_ARGUMENT');
+    }
+
+    /**
+     * test add named timestamps
+     */
+    public function test_add_named_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        $created_name = 'created';
+        $updated_name = 'updated';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `$table_name` ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $bm->add_timestamps($table_name, $created_name, $updated_name);
+        
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals($created_name, $col['field']);
+        $this->assertEquals('datetime', $col['type'] );
+        
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals($updated_name, $col['field']);
+        $this->assertEquals('timestamp', $col['type'] );
+
+        $this->remove_table($table_name);
+    }
+    
+    /**
+     * test remove named timestamps
+     */
+    public function test_remove_named_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        $created_name = 'created';
+        $updated_name = 'updated';
+
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE `$table_name` ( name varchar(20), `$created_name` datetime not null, `$updated_name` datetime not null );");
+
+        //verify they exists
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals($created_name, $col['field']);
+        
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals($updated_name, $col['field']);
+
+        //drop them
+        $bm->remove_timestamps($table_name, $created_name, $updated_name);
+
+        //verify they does not exist
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals(null, $col);
+        
+        $this->remove_table($table_name);
+    }
+
+    /**
      * test string quoting
      */
     public function test_string_quoting()

--- a/tests/unit/MySQLTableDefinitionTest.php
+++ b/tests/unit/MySQLTableDefinitionTest.php
@@ -153,6 +153,50 @@ class MySQLTableDefinitionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * test timestamp definition with default value
+     */
+    public function test_timestamps_with_default_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $table = $bm->create_table($table_name);
+        $table->timestamps();
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals('created_at', $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals('updated_at', $col['field']);
+        $this->assertEquals('timestamp', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+    /**
+     * test timestamp definition with defined value
+     */
+    public function test_timestamps_with_defined_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $created = "created";
+        $updated = "updated";
+        $table = $bm->create_table($table_name);
+        $table->timestamps($created, $updated);
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, $created);
+        $this->assertEquals($created, $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $col = $this->adapter->column_info($table_name, $updated);
+        $this->assertEquals($updated, $col['field']);
+        $this->assertEquals('timestamp', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+    /**
      * test multiple primary keys
      */
     public function test_multiple_primary_keys()

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -36,6 +36,9 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+        if(!$this->adapter)
+          return;
+        
         //delete any tables we created
         if ($this->adapter->has_table('users',true)) {
             $this->adapter->drop_table('users');

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -484,6 +484,152 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * test add timestamps
+     */
+    public function test_add_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE $table_name ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $bm->add_timestamps($table_name);
+        
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type'] );
+        
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type'] );
+
+        $this->drop_table($table_name);
+    }
+
+    /**
+     * test remove timestamps
+     */
+    public function test_remove_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE $table_name ( name varchar(20), created_at timestamp not null, updated_at timestamp not null );");
+        
+        //verify they exists
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals("created_at", $col['field']);
+        
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals("updated_at", $col['field']);
+
+        //drop them
+        $bm->remove_timestamps($table_name);
+
+        //verify they does not exist
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals(null, $col);
+        
+        $this->drop_table($table_name);
+    }
+
+    /**
+     * test add empty colmun names timestamps
+     */
+    public function test_add_empty_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE $table_name ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        try{
+          //add timestamps
+          $bm->add_timestamps($table_name, "", "");
+        } catch (Ruckusing_Exception $exception) {
+            if (Ruckusing_Exception::INVALID_ARGUMENT == $exception->getCode()) {
+                $this->drop_table($table_name);
+                return;
+            }
+        }
+        $this->fail('Expected to raise & catch Ruckusing_Exception::INVALID_ARGUMENT');
+    }
+
+    /**
+     * test add named timestamps
+     */
+    public function test_add_named_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        $created_name = 'created';
+        $updated_name = 'updated';
+        
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE $table_name ( name varchar(20) );");
+
+        $col = $this->adapter->column_info($table_name, "name");
+        $this->assertEquals("name", $col['field']);
+
+        //add timestamps
+        $bm->add_timestamps($table_name, $created_name, $updated_name);
+        
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals($created_name, $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type'] );
+        
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals($updated_name, $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type'] );
+
+        $this->drop_table($table_name);
+    }
+    
+    /**
+     * test remove named timestamps
+     */
+    public function test_remove_named_timestamps()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $table_name = 'users';
+        $created_name = 'created';
+        $updated_name = 'updated';
+
+        //create it
+        $this->adapter->execute_ddl("CREATE TABLE $table_name ( name varchar(20), $created_name timestamp not null, $updated_name timestamp not null );");
+
+        //verify they exists
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals($created_name, $col['field']);
+        
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals($updated_name, $col['field']);
+
+        //drop them
+        $bm->remove_timestamps($table_name, $created_name, $updated_name);
+
+        //verify they does not exist
+        $col = $this->adapter->column_info($table_name, $created_name);
+        $this->assertEquals(null, $col);
+        $col = $this->adapter->column_info($table_name, $updated_name);
+        $this->assertEquals(null, $col);
+        
+        $this->drop_table($table_name);
+    }
+
+    /**
      * test select all and returning
      */
     public function test_select_all_and_returning()

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -533,9 +533,14 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
         $bm->remove_timestamps($table_name);
 
         //verify they does not exist
+        $col = $this->adapter->column_info($table_name, "name");
+        fwrite(STDERR, print_r($col, TRUE));
+        $this->assertEquals('name', $col['field']);
         $col = $this->adapter->column_info($table_name, "created_at");
+        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         $col = $this->adapter->column_info($table_name, "updated_at");
+        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         
         $this->drop_table($table_name);
@@ -622,8 +627,10 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
 
         //verify they does not exist
         $col = $this->adapter->column_info($table_name, $created_name);
+        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         $col = $this->adapter->column_info($table_name, $updated_name);
+        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         
         $this->drop_table($table_name);

--- a/tests/unit/PostgresAdapterTest.php
+++ b/tests/unit/PostgresAdapterTest.php
@@ -364,7 +364,7 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
 
         //verify it does not exist
         $col = $this->adapter->column_info("users", "name");
-        $this->assertEquals(array(), $col);
+        $this->assertEquals(null, $col);
         $this->drop_table('users');
     }
 
@@ -534,13 +534,10 @@ class PostgresAdapterTest extends PHPUnit_Framework_TestCase
 
         //verify they does not exist
         $col = $this->adapter->column_info($table_name, "name");
-        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals('name', $col['field']);
         $col = $this->adapter->column_info($table_name, "created_at");
-        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         $col = $this->adapter->column_info($table_name, "updated_at");
-        fwrite(STDERR, print_r($col, TRUE));
         $this->assertEquals(null, $col);
         
         $this->drop_table($table_name);

--- a/tests/unit/PostgresTableDefinitionTest.php
+++ b/tests/unit/PostgresTableDefinitionTest.php
@@ -225,7 +225,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
 
         //make sure there is NO 'id' column
         $id_actual = $this->adapter->column_info($table_name, "id");
-        $this->assertEquals(array(), $id_actual);
+        $this->assertEquals(null, $id_actual);
         $bm->drop_table($table_name);
     }
 
@@ -249,7 +249,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
 
         //make sure there is NO 'id' column
         $id_actual = $this->adapter->column_info($table_name, "id");
-        $this->assertEquals(array(), $id_actual);
+        $this->assertEquals(null, $id_actual);
         $bm->drop_table($table_name);
     }
 
@@ -264,7 +264,7 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
         $actual = $t1->finish();
 
         $col = $this->adapter->column_info("users", "id");
-        $this->assertEquals(array(), $col);
+        $this->assertEquals(null, $col);
 
         $primary_keys = $this->adapter->primary_keys('users');
         $this->assertEquals(array(), $primary_keys);

--- a/tests/unit/PostgresTableDefinitionTest.php
+++ b/tests/unit/PostgresTableDefinitionTest.php
@@ -35,6 +35,8 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
      */
     protected function tearDown()
     {
+        if(!$this->adapter)
+            return;
         //delete any tables we created
         if ($this->adapter->has_table('users',true)) {
             $this->adapter->drop_table('users');

--- a/tests/unit/PostgresTableDefinitionTest.php
+++ b/tests/unit/PostgresTableDefinitionTest.php
@@ -155,6 +155,50 @@ class PostgresTableDefinitionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * test timestamp definition with default value
+     */
+    public function test_timestamps_with_default_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $table = $bm->create_table($table_name);
+        $table->timestamps();
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals('created_at', $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type']);
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals('updated_at', $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+    /**
+     * test timestamp definition with defined value
+     */
+    public function test_timestamps_with_defined_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $created = "created";
+        $updated = "updated";
+        $table = $bm->create_table($table_name);
+        $table->timestamps($created, $updated);
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, $created);
+        $this->assertEquals($created, $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type']);
+        $col = $this->adapter->column_info($table_name, $updated);
+        $this->assertEquals($updated, $col['field']);
+        $this->assertEquals('timestamp without time zone', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+    /**
      * test multiple primary keys
      */
     public function test_multiple_primary_keys()

--- a/tests/unit/Sqlite3AdapterTest.php
+++ b/tests/unit/Sqlite3AdapterTest.php
@@ -414,6 +414,31 @@ class Sqlite3AdapterTest extends PHPUnit_Framework_TestCase
         $this->drop_table('users');
     }
 
+    public function test_add_timestamps()
+    {
+      $this->markTestSkipped('In sqlite alter columns operations are unsupported - http://www.sqlite.org/omitted.html');
+    }
+
+    public function test_remove_timestamps()
+    {
+        $this->markTestSkipped('In sqlite alter columns operations are unsupported - http://www.sqlite.org/omitted.html');
+    }
+
+    public function test_add_empty_timestamps()
+    {
+        $this->markTestSkipped('In sqlite alter columns operations are unsupported - http://www.sqlite.org/omitted.html');
+    }
+
+    public function test_add_named_timestamps()
+    {
+        $this->markTestSkipped('In sqlite alter columns operations are unsupported - http://www.sqlite.org/omitted.html');
+    }
+
+    public function test_remove_named_timestamps()
+    {
+        $this->markTestSkipped('In sqlite alter columns operations are unsupported - http://www.sqlite.org/omitted.html');
+    }
+
     public function test_select_all_and_returning()
     {
         $table = $this->adapter->create_table('users');

--- a/tests/unit/Sqlite3TableDefinitionTest.php
+++ b/tests/unit/Sqlite3TableDefinitionTest.php
@@ -93,6 +93,45 @@ class Sqlite3TableDefinitionTest extends PHPUnit_Framework_TestCase
         $bm->drop_table($table_name);
     }
 
+    public function test_timestamps_with_default_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $table = $bm->create_table($table_name);
+        $table->timestamps();
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, "created_at");
+        $this->assertEquals('created_at', $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $col = $this->adapter->column_info($table_name, "updated_at");
+        $this->assertEquals('updated_at', $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+    public function test_timestamps_with_defined_value()
+    {
+        $bm = new Ruckusing_Migration_Base($this->adapter);
+        $ts = time();
+        $table_name = "users_$ts";
+        $created = "created";
+        $updated = "updated";
+        $table = $bm->create_table($table_name);
+        $table->timestamps($created, $updated);
+        $table->finish();
+
+        $col = $this->adapter->column_info($table_name, $created);
+        $this->assertEquals($created, $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $col = $this->adapter->column_info($table_name, $updated);
+        $this->assertEquals($updated, $col['field']);
+        $this->assertEquals('datetime', $col['type']);
+        $bm->drop_table($table_name);
+    }
+
+
     public function test_multiple_primary_keys()
     {
         $bm = new Ruckusing_Migration_Base($this->adapter);


### PR DESCRIPTION
I did this request some time ago already and it got misunderstood probably.
This is more a convenience/standard function than a built-in for an potential active record. There is a high chance that at some point in a project you need to save created_at and updated_at timestamps for, say a _user_ or an _order_. This built-in function can help doing that very easily.

    $this->timestamps();

vs.

    $this->column('created_at', 'datetime');
    $this->column('updated_at', 'timestamp', array("null" => false, 'default' => 'CURRENT_TIMESTAMP', 'extra' => 'ON UPDATE CURRENT_TIMESTAMP');

This patch includes also implementation of `extra` option for MySQL adapter and the support of command default value `CURRENT_TIMESTAMP`