### PR TITLE
use Identifier on Index name

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -767,7 +767,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
         }
         $sql = sprintf("CREATE %sINDEX %s ON %s(%s)",
                 $unique ? "UNIQUE " : "",
-                $index_name,
+                $this->identifier($index_name),
                 $this->identifier($table_name),
                 join(", ", $cols));
 


### PR DESCRIPTION
Use identifier on index name, it would throw an error when is not a valid index name, for example using spaces or symbol, in my case It throw an error trying create a index name with dash `column-index`.