### PR TITLE
Avoid schema constant

### DIFF
--- a/lib/Ruckusing/Adapter/Base.php
+++ b/lib/Ruckusing/Adapter/Base.php
@@ -150,4 +150,15 @@ class Ruckusing_Adapter_Base
         return $this->table_exists($tbl);
     }
 
+    /**
+     * Allows to override hardcoded schema table name constant in case of parallel migrations.
+     *
+     * @return string
+     */
+    public function get_schema_version_table_name() {
+        if (isset($this->_dsn['schema_version_table_name'])) {
+            return $this->_dsn['schema_version_table_name'];
+        }
+        return RUCKUSING_TS_SCHEMA_TBL_NAME;
+    }
 }

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -136,11 +136,11 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
      */
     public function create_schema_version_table()
     {
-        if (!$this->has_table(RUCKUSING_TS_SCHEMA_TBL_NAME)) {
-            $t = $this->create_table(RUCKUSING_TS_SCHEMA_TBL_NAME, array('id' => false));
+        if (!$this->has_table($this->get_schema_version_table_name())) {
+            $t = $this->create_table($this->get_schema_version_table_name(), array('id' => false));
             $t->column('version', 'string');
             $t->finish();
-            $this->add_index(RUCKUSING_TS_SCHEMA_TBL_NAME, 'version', array('unique' => true));
+            $this->add_index($this->get_schema_version_table_name(), 'version', array('unique' => true));
         }
     }
 
@@ -1191,7 +1191,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
      */
     public function set_current_version($version)
     {
-        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", $this->get_schema_version_table_name(), $version);
 
         return $this->execute_ddl($sql);
     }
@@ -1205,7 +1205,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
      */
     public function remove_version($version)
     {
-        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", $this->get_schema_version_table_name(), $version);
 
         return $this->execute_ddl($sql);
     }

--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -139,11 +139,11 @@ class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruc
      */
     public function create_schema_version_table()
     {
-        if (!$this->has_table(RUCKUSING_TS_SCHEMA_TBL_NAME)) {
-            $t = $this->create_table(RUCKUSING_TS_SCHEMA_TBL_NAME, array('id' => false));
+        if (!$this->has_table($this->get_schema_version_table_name())) {
+            $t = $this->create_table($this->get_schema_version_table_name(), array('id' => false));
             $t->column('version', 'string');
             $t->finish();
-            $this->add_index(RUCKUSING_TS_SCHEMA_TBL_NAME, 'version', array('unique' => true));
+            $this->add_index($this->get_schema_version_table_name(), 'version', array('unique' => true));
         }
     }
 
@@ -1303,7 +1303,7 @@ SQL;
      */
     public function set_current_version($version)
     {
-        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", $this->get_schema_version_table_name(), $version);
 
         return $this->execute_ddl($sql);
     }
@@ -1317,7 +1317,7 @@ SQL;
      */
     public function remove_version($version)
     {
-        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", $this->get_schema_version_table_name(), $version);
 
         return $this->execute_ddl($sql);
     }

--- a/lib/Ruckusing/Adapter/Sqlite3/Base.php
+++ b/lib/Ruckusing/Adapter/Sqlite3/Base.php
@@ -94,11 +94,11 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
      */
     public function create_schema_version_table()
     {
-        if (!$this->has_table(RUCKUSING_TS_SCHEMA_TBL_NAME)) {
-            $t = $this->create_table(RUCKUSING_TS_SCHEMA_TBL_NAME, array('id' => false));
+        if (!$this->has_table($this->get_schema_version_table_name())) {
+            $t = $this->create_table($this->get_schema_version_table_name(), array('id' => false));
             $t->column('version', 'string');
             $t->finish();
-            $this->add_index(RUCKUSING_TS_SCHEMA_TBL_NAME, 'version', array('unique' => true));
+            $this->add_index($this->get_schema_version_table_name(), 'version', array('unique' => true));
         }
     }
 
@@ -857,7 +857,7 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
      */
     public function set_current_version($version)
     {
-        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("INSERT INTO %s (version) VALUES ('%s')", $this->get_schema_version_table_name(), $version);
         return $this->execute_ddl($sql);
     }
 
@@ -867,7 +867,7 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
      */
     public function remove_version($version)
     {
-        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", RUCKUSING_TS_SCHEMA_TBL_NAME, $version);
+        $sql = sprintf("DELETE FROM %s WHERE version = '%s'", $this->get_schema_version_table_name(), $version);
         return $this->execute_ddl($sql);
     }
 

--- a/lib/Ruckusing/FrameworkRunner.php
+++ b/lib/Ruckusing/FrameworkRunner.php
@@ -354,12 +354,12 @@ class Ruckusing_FrameworkRunner
             $existing_version_old_style = $this->_adapter->select_one($query_sql);
             if (count($existing_version_old_style) > 0) {
                 //make sure it doesnt exist in our new table, who knows how it got inserted?
-                $new_vers_sql = sprintf("SELECT version FROM %s WHERE version = %d", RUCKUSING_TS_SCHEMA_TBL_NAME, $file['version']);
+                $new_vers_sql = sprintf("SELECT version FROM %s WHERE version = %d", $this->_adapter->get_schema_version_table_name(), $file['version']);
                 $existing_version_new_style = $this->_adapter->select_one($new_vers_sql);
                 if (empty($existing_version_new_style)) {
                     // use sprintf & %d to force it to be stripped of any leading zeros, we *know* this represents an old version style
                     // so we dont have to worry about PHP and integer overflow
-                    $insert_sql = sprintf("INSERT INTO %s (version) VALUES (%d)", RUCKUSING_TS_SCHEMA_TBL_NAME, $file['version']);
+                    $insert_sql = sprintf("INSERT INTO %s (version) VALUES (%d)", $this->_adapter->get_schema_version_table_name(), $file['version']);
                     $this->_adapter->query($insert_sql);
                 }
             }

--- a/lib/Ruckusing/Util/Migrator.php
+++ b/lib/Ruckusing/Util/Migrator.php
@@ -75,7 +75,7 @@ class Ruckusing_Util_Migrator
         // We only want one row but we cannot assume that we are using MySQL and use a LIMIT statement
         // as it is not part of the SQL standard. Thus we have to select all rows and use PHP to return
         // the record we need
-        $versions_nested = $this->_adapter->select_all(sprintf("SELECT version FROM %s", RUCKUSING_TS_SCHEMA_TBL_NAME));
+        $versions_nested = $this->_adapter->select_all(sprintf("SELECT version FROM %s", $this->_adapter->get_schema_version_table_name()));
         $versions = array();
         foreach ($versions_nested as $v) {
             $versions[] = $v['version'];
@@ -329,7 +329,7 @@ class Ruckusing_Util_Migrator
      */
     private function executed_migrations()
     {
-        $query_sql = sprintf('SELECT version FROM %s', RUCKUSING_TS_SCHEMA_TBL_NAME);
+        $query_sql = sprintf('SELECT version FROM %s', $this->_adapter->get_schema_version_table_name());
         $versions = $this->_adapter->select_all($query_sql);
         $executed = array();
         foreach ($versions as $v) {

--- a/lib/Task/Db/Migrate.php
+++ b/lib/Task/Db/Migrate.php
@@ -313,7 +313,7 @@ class Task_Db_Migrate extends Ruckusing_Task_Base implements Ruckusing_Task_Inte
      */
     private function verify_environment()
     {
-        if (!$this->_adapter->table_exists(RUCKUSING_TS_SCHEMA_TBL_NAME) ) {
+        if (!$this->_adapter->table_exists($this->_adapter->get_schema_version_table_name()) ) {
             $this->_return .= "\n\tSchema version table does not exist. Auto-creating.";
             $this->auto_create_schema_info_table();
         }
@@ -341,7 +341,7 @@ class Task_Db_Migrate extends Ruckusing_Task_Base implements Ruckusing_Task_Inte
     private function auto_create_schema_info_table()
     {
         try {
-            $this->_return .= sprintf("\n\tCreating schema version table: %s", RUCKUSING_TS_SCHEMA_TBL_NAME . "\n\n");
+            $this->_return .= sprintf("\n\tCreating schema version table: %s", $this->_adapter->get_schema_version_table_name() . "\n\n");
             $this->_adapter->create_schema_version_table();
 
             return true;

--- a/lib/Task/Db/Setup.php
+++ b/lib/Task/Db/Setup.php
@@ -54,12 +54,12 @@ class Task_Db_Setup extends Ruckusing_Task_Base implements Ruckusing_Task_Interf
         $output = "Started: " . date('Y-m-d g:ia T') . "\n\n";
         $output .= "[db:setup]: \n";
         //it doesnt exist, create it
-        if (!$this->_adapter->table_exists(RUCKUSING_TS_SCHEMA_TBL_NAME)) {
-            $output .= sprintf("\tCreating table: %s", RUCKUSING_TS_SCHEMA_TBL_NAME);
+        if (!$this->_adapter->table_exists($this->_adapter->get_schema_version_table_name())) {
+            $output .= sprintf("\tCreating table: %s", $this->_adapter->get_schema_version_table_name());
             $this->_adapter->create_schema_version_table();
             $output .= "\n\tDone.\n";
         } else {
-            $output .= sprintf("\tNOTICE: table '%s' already exists. Nothing to do.", RUCKUSING_TS_SCHEMA_TBL_NAME);
+            $output .= sprintf("\tNOTICE: table '%s' already exists. Nothing to do.", $this->_adapter->get_schema_version_table_name());
         }
         $output .= "\n\nFinished: " . date('Y-m-d g:ia T') . "\n\n";
 

--- a/lib/Task/Db/Version.php
+++ b/lib/Task/Db/Version.php
@@ -51,15 +51,15 @@ class Task_Db_Version extends Ruckusing_Task_Base implements Ruckusing_Task_Inte
     {
         $output = "Started: " . date('Y-m-d g:ia T') . "\n\n";
         $output .= "[db:version]: \n";
-        if (!$this->_adapter->table_exists(RUCKUSING_TS_SCHEMA_TBL_NAME)) {
+        if (!$this->_adapter->table_exists($this->_adapter->get_schema_version_table_name())) {
             //it doesnt exist, create it
-            $output .= "\tSchema version table (" . RUCKUSING_TS_SCHEMA_TBL_NAME . ") does not exist. Do you need to run 'db:setup'?";
+            $output .= "\tSchema version table (" . $this->_adapter->get_schema_version_table_name() . ") does not exist. Do you need to run 'db:setup'?";
         } else {
             //it exists, read the version from it
             // We only want one row but we cannot assume that we are using MySQL and use a LIMIT statement
             // as it is not part of the SQL standard. Thus we have to select all rows and use PHP to return
             // the record we need
-            $versions_nested = $this->_adapter->select_all(sprintf("SELECT version FROM %s", RUCKUSING_TS_SCHEMA_TBL_NAME));
+            $versions_nested = $this->_adapter->select_all(sprintf("SELECT version FROM %s", $this->_adapter->get_schema_version_table_name()));
             $versions = array();
             foreach ($versions_nested as $v) {
                 $versions[] = $v['version'];

--- a/tests/dummy/db/migrations/multi_schema_test_dir/20151122000000_CreatePrefixedTable.php
+++ b/tests/dummy/db/migrations/multi_schema_test_dir/20151122000000_CreatePrefixedTable.php
@@ -1,0 +1,24 @@
+<?php
+
+class CreatePrefixedTable extends Ruckusing_Migration_Base
+{
+    public function up()
+    {
+        $this->execute('
+            CREATE TABLE ' . $this->get_prefix() . 'some_table (id INT)
+        ');
+    }
+
+    public function down()
+    {
+        $this->execute('
+            DROP TABLE ' . $this->get_prefix() . 'some_table
+        ');
+    }
+
+    private function get_prefix()
+    {
+        $dsn = $this->get_adapter()->get_dsn();
+        return $dsn['prefix'];
+    }
+}

--- a/tests/unit/BaseAdapterOverrideSchemaTest.php
+++ b/tests/unit/BaseAdapterOverrideSchemaTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Sometimes we need to have parallel migrations: many schema versions tables
+ * and own tables (with prefixes).
+ *
+ * By default we use single-way mode using RUCKUSING_TS_SCHEMA_TBL_NAME constant.
+ * When we want to override this and has many parallel migrations,
+ * we use DSN's schema_version_table_name param, that will override constant.
+ *
+ *
+ * @category Ruckusing_Tests
+ * @package  Ruckusing_Migrations
+ * @author   (c) Alexander Ustimenko < a % ustimen . co >
+*/
+class BaseAdapterOverrideSchemaTest extends PHPUnit_Framework_TestCase
+{
+
+    private $config;
+
+    protected function setUp()
+    {
+        $this->config = require RUCKUSING_BASE . '/config/database.inc.php';
+
+        if (!is_array($this->config) || !(array_key_exists('db', $this->config) && array_key_exists('mysql_test', $this->config['db']))) {
+            $this->markTestSkipped("\n'mysql_test' DB is not defined in config/database.inc.php\n\n");
+        }
+
+        $this->config['db']['mysql_test']['directory'] = 'multi_schema_test_dir';
+    }
+
+    /**
+     * @dataProvider prefixProvider
+     * @param string $prefix
+     */
+    public function testOverrideVersionsTableByPrefix($prefix)
+    {
+        $this->config['db']['mysql_test']['prefix'] = $prefix;
+        $this->config['db']['mysql_test']['schema_version_table_name'] = $prefix . 'schema_migrations';
+
+        $runner  = new Ruckusing_FrameworkRunner($this->config, array(__FILE__, 'ENV=mysql_test', 'db:migrate'));
+        $output  = $runner->execute();
+        /* @var $adapter Ruckusing_Adapter_MySQL_Base */
+        $adapter = $runner->get_adapter();
+
+        $this->assertContains('Creating schema version table: ' . $prefix . 'schema_migrations', $output);
+        $this->assertContains('CreatePrefixedTable', $output);
+
+        $this->assertTrue($adapter->table_exists($prefix . 'schema_migrations', true));
+        $this->assertTrue($adapter->table_exists($prefix . 'some_table', true));
+
+        return $prefix;
+    }
+
+    /**
+     * @dataProvider prefixProvider
+     * @param string $prefix
+     */
+    public function testRevertPrefixedTables($prefix)
+    {
+        $this->config['db']['mysql_test']['prefix'] = $prefix;
+        $this->config['db']['mysql_test']['schema_version_table_name'] = $prefix . 'schema_migrations';
+
+        $runner  = new Ruckusing_FrameworkRunner($this->config, array(__FILE__, 'ENV=mysql_test', 'db:migrate', 'VERSION=0'));
+        $output  = $runner->execute();
+        /* @var $adapter Ruckusing_Adapter_MySQL_Base */
+        $adapter = $runner->get_adapter();
+        $runner->logger = null;
+        $runner->initialize_logger();
+        $adapter->logger = $runner->logger;
+        $adapter->drop_table($adapter->get_schema_version_table_name());
+
+        $this->assertFalse($adapter->table_exists($prefix . 'schema_migrations', true));
+        $this->assertFalse($adapter->table_exists($prefix . 'some_table', true));
+    }
+
+    public function prefixProvider()
+    {
+        return array(
+            array('prefix1_'),
+            array('prefix2_'),
+        );
+    }
+}


### PR DESCRIPTION
Sometimes we need to have parallel migrations: many schema versions tables and own tables (with prefixes).

By default we use single-way mode using RUCKUSING_TS_SCHEMA_TBL_NAME constant.
When we want to override this and has many parallel migrations, we use DSN's schema_version_table_name param, that will override constant.

Locally tests are ok (for mysql/sqlite). New test with two parallel runners added.