### PR TITLE
Fixes transaction state after commit

### DIFF
--- a/lib/Ruckusing/Adapter/Sqlite3/Base.php
+++ b/lib/Ruckusing/Adapter/Sqlite3/Base.php
@@ -900,7 +900,7 @@ class Ruckusing_Adapter_Sqlite3_Base extends Ruckusing_Adapter_Base implements R
             throw new Ruckusing_Exception('Transaction not started', Ruckusing_Exception::QUERY_ERROR);
         }
         $this->execute_ddl("COMMIT");
-        $this->_in_transaction = true;
+        $this->_in_transaction = false;
     }
 
     /**


### PR DESCRIPTION
Use SQLite adpater, I encountered a problem when using two (or more) migrations : 
`Base.php(184) : SQLite3::query(): Unable to execute statement: cannot commit - no transaction is active`

After a quick look at adapter code, it seems that transaction state was not correctly reset after `COMMIT`.

This PR contains a fix that make it works correctly.
