### PR TITLE
PgSQL adapter: fix NULL substitution on column option change

### DIFF
--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -825,7 +825,7 @@ SQL;
      */
     private function change_column_null($table_name, $column_name, $null, $default = null)
     {
-        if (($null !== false) || ($default !== null)) {
+        if (($null === false) || ($default !== null)) {
             $sql = sprintf("UPDATE %s SET %s=%s WHERE %s IS NULL",
                     $this->quote_table_name($table_name),
                     $this->quote_column_name($column_name),


### PR DESCRIPTION
In change_column_null() function of PgSQL adapter, we have a typo (I think).

When $null is true, it means that NULL is "allowed" in column and false means DB should not allow NULL (ie. set NOT NULL on column option).
So, if $null is true, we dont need to replace values which are set to NULL but when $null is false, we (potentially) have to.

This PR fixes this point : it changes "if" condition to apply an UPDATE of NULL values when $null is false.