### PR TITLE
fix: don't exit on deprecation warnings

### DIFF
--- a/lib/Ruckusing/Exception.php
+++ b/lib/Ruckusing/Exception.php
@@ -79,7 +79,7 @@ class Ruckusing_Exception extends Exception
     public static function errorHandler($code, $message, $file, $line)
     {
         file_put_contents('php://stderr', "\n" . basename($file) . "({$line}) : {$message}\n\n");
-        if ($code != E_WARNING && $code != E_NOTICE) {
+        if ($code != E_WARNING && $code != E_NOTICE && $code != E_DEPRECATED) {
             exit(1);
         }
     }


### PR DESCRIPTION
This PR is to stop ruckusing-migrations exiting on deprecation warnings.

Creating a migration to move from using mcrypt to openssl resulted in the migration failing to complete due to the mcrypt functions being deprecated. Trying to suppress deprecation warnings wouldn't work as the error handler forcibly exits if the error isn't E_WARNING or E_NOTICE. I've added E_DEPRECATED in as well so that the message still shows, but the migration will continue.