### PR TITLE
Enabled SSL Support for MySQLI

### DIFF
--- a/config/database.inc.php
+++ b/config/database.inc.php
@@ -23,7 +23,14 @@ return array(
             'password' => '',
             //'charset' => 'utf8',
             //'directory' => 'custom_name',
-            //'socket' => '/var/run/mysqld/mysqld.sock'
+            //'socket' => '/var/run/mysqld/mysqld.sock',
+            //'ssl_enabled' => false,
+            //# For TLS/SSL, the following settings are used in mysqli_ssl_set.
+            //'ssl_key' => 'key.pem',
+            //'ssl_certificate' => 'cert.pem',
+            //'ssl_ca_certificate' => 'cacert.pem',
+            //'ssl_ca_path' => NULL,
+            //'ssl_cipher_algos' => NULL,
         ),
         'pg_test' => array(
             'type' => 'pgsql',

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -1257,7 +1257,28 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
             if (empty($db_info['charset'])) {
                 $db_info['charset'] = "utf8";
             }
-            $this->conn = new mysqli($db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']); //db name leaved for selection
+            if (!empty($db_info['ssl_enabled']) && $db_info['ssl_enabled'] === true) {
+                $this->conn = mysqli_init();
+                if (empty($db_info['ssl_key'])) {
+                    $db_info['ssl_key'] = null;
+                }
+                if (empty($db_info['ssl_certificate'])) {
+                    $db_info['ssl_certificate'] = null;
+                }
+                if (empty($db_info['ssl_ca_certificate'])) {
+                    $db_info['ssl_ca_certificate'] = null;
+                }
+                if (empty($db_info['ssl_ca_path'])) {
+                    $db_info['ssl_ca_path'] = null;
+                }
+                if (empty($db_info['ssl_cipher_algos'])) {
+                    $db_info['ssl_cipher_algos'] = null;
+                }
+                mysqli_ssl_set($this->conn, $db_info['ssl_key'], $db_info['ssl_certificate'], $db_info['ssl_ca_certificate'], $db_info['ssl_ca_path'], $db_info['ssl_cipher_algos']);
+                $this->conn->real_connect($this->conn, $db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']);
+            } else {
+                $this->conn = new mysqli($db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']); //db name leaved for selection
+            }
             if ($this->conn->connect_error) {
                 throw new Ruckusing_Exception(
                         "\n\nCould not connect to the DB, check host / user / password\n\n",

--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -1274,7 +1274,7 @@ class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruc
                 if (empty($db_info['ssl_cipher_algos'])) {
                     $db_info['ssl_cipher_algos'] = null;
                 }
-                mysqli_ssl_set($this->conn, $db_info['ssl_key'], $db_info['ssl_certificate'], $db_info['ssl_ca_certificate'], $db_info['ssl_ca_path'], $db_info['ssl_cipher_algos']);
+                $this->conn->ssl_set($db_info['ssl_key'], $db_info['ssl_certificate'], $db_info['ssl_ca_certificate'], $db_info['ssl_ca_path'], $db_info['ssl_cipher_algos']);
                 $this->conn->real_connect($this->conn, $db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']);
             } else {
                 $this->conn = new mysqli($db_info['host'], $db_info['user'], $db_info['password'], '', $db_info['port'], $db_info['socket']); //db name leaved for selection


### PR DESCRIPTION
Adds in additional configuration settings for MySQL to allow SSL connections.

This allows those that rely on SSL connections to MySQL to configure them optionally. This is required for many cloud hosting providers of MySQL and helps increase systems security. By setting a new config `ssl_enabled` to true then both `ssl-set` and `mysqli->real_connect` will be used.

The default is to continue with the existing connection method and `ssl_enabled` to false.

This setting was available from PHP5 so should not break any backwards compatibility.