### PR TITLE
Remove dynamic properties deprecation failure for php8

### DIFF
--- a/lib/Ruckusing/Adapter/PgSQL/Base.php
+++ b/lib/Ruckusing/Adapter/PgSQL/Base.php
@@ -24,6 +24,8 @@ define('PG_MAX_IDENTIFIER_LENGTH', 64);
  */
 class Ruckusing_Adapter_PgSQL_Base extends Ruckusing_Adapter_Base implements Ruckusing_Adapter_Interface
 {
+    private $db_info;
+    private $conn;
     /**
      * Name of adapter
      *

--- a/lib/Ruckusing/FrameworkRunner.php
+++ b/lib/Ruckusing/FrameworkRunner.php
@@ -22,6 +22,7 @@
  */
 class Ruckusing_FrameworkRunner
 {
+    private $logger;
     /**
      * reference to our DB connection
      *

--- a/lib/Ruckusing/Task/Manager.php
+++ b/lib/Ruckusing/Task/Manager.php
@@ -21,6 +21,7 @@ define('RUCKUSING_TASK_DIR', RUCKUSING_BASE . DIRECTORY_SEPARATOR . 'lib' . DIRE
  */
 class Ruckusing_Task_Manager
 {
+    private $_config;
     /**
      * adapter
      *


### PR DESCRIPTION
When trying to use ruckus-migrations with php 8 an error gets raised because of dynamic properties being deprecated in this version. This PR fixes it by declaring the missing properties.