### PR TITLE
Remove dynamic properties deprecation failure for php8 in MySQL adapter

### DIFF
--- a/lib/Ruckusing/Adapter/MySQL/Base.php
+++ b/lib/Ruckusing/Adapter/MySQL/Base.php
@@ -24,6 +24,8 @@ define('MYSQL_MAX_IDENTIFIER_LENGTH', 64);
  */
 class Ruckusing_Adapter_MySQL_Base extends Ruckusing_Adapter_Base implements Ruckusing_Adapter_Interface
 {
+    private $db_info;
+    private $conn;
     /**
      * Name of adapter
      *


### PR DESCRIPTION
In follow-up to #188 : remove warnings with PHP 8 in MySQL adapter