### PR TITLE
Fix php84 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "license": "MIT",
     "name": "ruckusing/ruckusing-migrations",
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/lib/Ruckusing/Exception.php
+++ b/lib/Ruckusing/Exception.php
@@ -48,7 +48,7 @@ class Ruckusing_Exception extends Exception
      *
      * @return Ruckusing_Exception
      */
-    public function __construct($message, $code = 0, Exception $previous = null)
+    public function __construct($message, $code = 0, ?Exception $previous = null)
     {
         // make sure everything is assigned properly
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {

--- a/lib/Ruckusing/FrameworkRunner.php
+++ b/lib/Ruckusing/FrameworkRunner.php
@@ -107,7 +107,7 @@ class Ruckusing_FrameworkRunner
      *
      * @return Ruckusing_FrameworkRunner
      */
-    public function __construct($config, $argv, Ruckusing_Util_Logger $log = null)
+    public function __construct($config, $argv, ?Ruckusing_Util_Logger $log = null)
     {
         set_error_handler(array('Ruckusing_Exception', 'errorHandler'), E_ALL);
         set_exception_handler(array('Ruckusing_Exception', 'exceptionHandler'));


### PR DESCRIPTION
This PR fixes PHP warnings in PHP 8.4. However those fixes are compatible only from PHP 7.1 and up.